### PR TITLE
Fix typo in 'period_this_month' string

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -157,7 +157,7 @@
   <string name="period_today">Dzisiaj</string>
   <string name="period_yesterday">Wczoraj</string>
   <string name="period_this_week">Bieżacy tydzień</string>
-  <string name="period_this_month">Bieżący miesiąć</string>
+  <string name="period_this_month">Bieżący miesiąc</string>
   <string name="period_last_week">Poprzedni tydzień</string>
   <string name="period_last_month">Poprzedni miesiąc</string>
   <string name="currency_name">Nazwa</string>


### PR DESCRIPTION
Typo in polish translation