### PR TITLE
fix: accidental list jumps from ListView fast scroll (toggle dynamically)

### DIFF
--- a/app/src/main/java/tw/tib/financisto/activity/BlotterFragment.java
+++ b/app/src/main/java/tw/tib/financisto/activity/BlotterFragment.java
@@ -210,6 +210,11 @@ public class BlotterFragment extends AbstractListFragment<Cursor> implements Blo
         // onViewCreated will create and start loader, which will use blotterFilter prepared above
         super.onViewCreated(view, savedInstanceState);
 
+        // Fast scroll is toggled dynamically: disabled while idle so the invisible
+        // thumb no longer intercepts right-edge touches, enabled while scrolling.
+        // MassOp / BudgetBlotter inherit this too.
+        tw.tib.financisto.utils.SafeFastScroll.attach(getListView());
+
         if (!mainBlotter) {
             // non-main blotter is contained in BlotterActivity, with fragment container layout
             // having a toolbar

--- a/app/src/main/java/tw/tib/financisto/utils/SafeFastScroll.java
+++ b/app/src/main/java/tw/tib/financisto/utils/SafeFastScroll.java
@@ -1,0 +1,54 @@
+package tw.tib.financisto.utils;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.AbsListView;
+
+/**
+ * Works around accidental jumps caused by ListView's built-in fast scroll:
+ * the framework FastScroller keeps intercepting right-edge touches even after
+ * the thumb has fully faded out, so touching near the right edge of an idle
+ * list suddenly teleports it. Very easy to hit on long lists.
+ *
+ * Fix: toggle fast scroll dynamically. Keep it disabled while idle (the right
+ * edge is not intercepted at all), enable it when scrolling starts (the thumb
+ * becomes visible and grabbable), then disable it again shortly after
+ * scrolling stops. Mirrors the androidx RecyclerView behavior where the thumb
+ * is only grabbable while visible.
+ */
+public class SafeFastScroll {
+
+    /** Delay before disabling fast scroll after scrolling stops (ms). The thumb's own fade-out is shorter, so this looks natural. */
+    private static final long DISABLE_DELAY_MS = 1500;
+
+    public static void attach(final AbsListView list) {
+        list.setFastScrollEnabled(false);   // disabled while idle: no invisible interception
+        final Handler handler = new Handler(Looper.getMainLooper());
+        final Runnable disable = () -> list.setFastScrollEnabled(false);
+        list.setOnScrollListener(new AbsListView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(AbsListView view, int scrollState) {
+                if (scrollState == SCROLL_STATE_IDLE) {
+                    handler.postDelayed(disable, DISABLE_DELAY_MS);
+                } else {
+                    handler.removeCallbacks(disable);
+                    if (!view.isFastScrollEnabled()) {
+                        view.setFastScrollEnabled(true);
+                    }
+                }
+            }
+
+            @Override
+            public void onScroll(AbsListView view, int firstVisibleItem,
+                                 int visibleItemCount, int totalItemCount) {
+                // While dragging the thumb the state may stay IDLE, but onScroll
+                // keeps firing; treat it as activity and postpone disabling, so the
+                // thumb does not vanish under the user's finger.
+                if (view.isFastScrollEnabled()) {
+                    handler.removeCallbacks(disable);
+                    handler.postDelayed(disable, DISABLE_DELAY_MS);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/blotter.xml
+++ b/app/src/main/res/layout/blotter.xml
@@ -44,7 +44,7 @@
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
 			android:cacheColorHint="@android:color/transparent"
-			android:fastScrollEnabled="true" />
+			android:fastScrollEnabled="false" /> <!-- toggled dynamically, see SafeFastScroll -->
 
 		<TextView
 			android:id="@android:id/empty"

--- a/app/src/main/res/layout/blotter_mass_op.xml
+++ b/app/src/main/res/layout/blotter_mass_op.xml
@@ -42,7 +42,7 @@
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
 			android:cacheColorHint="@android:color/transparent"
-			android:fastScrollEnabled="true" >
+			android:fastScrollEnabled="false" > <!-- toggled dynamically, see SafeFastScroll -->
 		</ListView>
 		<TextView android:id="@android:id/empty" android:layout_width="fill_parent"
 			android:layout_height="wrap_content"


### PR DESCRIPTION
As discussed in #121 (item 1).

With `android:fastScrollEnabled="true"` the framework FastScroller keeps intercepting right-edge touches even after the thumb has fully faded out, so scrolling near the right edge of an idle list suddenly teleports it. Long transaction lists make this easy to hit.

This PR toggles fast scroll dynamically via a small `SafeFastScroll` helper:

- disabled while idle → the right edge is not intercepted at all
- enabled when scrolling starts → thumb visible = grabbable, fast scroll works as before
- disabled again 1.5 s after scrolling stops; dragging the thumb keeps postponing the disable so it never vanishes under the user's finger

Same UX as RecyclerView's "grabbable only while visible". Attached in `BlotterFragment`, so MassOp / BudgetBlotter inherit it. Comments are in English per your note.