### PR TITLE
perf: sum same-currency rows in SQL for totals; hoist getColumnIndex out of report loops

### DIFF
--- a/app/src/main/java/tw/tib/financisto/db/TransactionsTotalCalculator.java
+++ b/app/src/main/java/tw/tib/financisto/db/TransactionsTotalCalculator.java
@@ -114,17 +114,45 @@ public class TransactionsTotalCalculator {
         return copy;
     }
 
+    /**
+     * Hybrid aggregation (performance): previously ALL matching rows (the main
+     * blotter is roughly every transaction) were pulled into Java and converted
+     * row by row — tens of thousands of rows across JNI plus per-row BigDecimal
+     * work made the total bar slow.
+     *
+     * getConvertedAmount's branch order guarantees that rows whose from-side
+     * currency equals the target currency ALWAYS contribute +from_amount
+     * (to/original are never consulted for them), so those rows (the vast
+     * majority) can be summed directly in SQL; only rows with a different
+     * from-side currency (foreign, usually very few) still need the original
+     * per-row conversion. Adding the two parts is exactly equivalent to the
+     * row-by-row version (integer SUM has no rounding; truncation still
+     * happens only at the final longValue()).
+     */
     private Total getBalanceInHomeCurrency(String view, Currency toCurrency, WhereFilter filter) {
         Log.d("Financisto", "Query balance: "+filter.getSelection()+" => "+ Arrays.toString(filter.getSelectionArgs()));
-        Cursor c;
-        c = db.db().query(view, HOME_CURRENCY_PROJECTION,
-                filter.getSelection(), filter.getSelectionArgs(),
-                null, null, null);
+        long t0 = System.currentTimeMillis();
+        // fast path: from-side already in the target currency, SUM directly in SQL
+        long homeSum = 0;
+        Cursor hc = db.db().query(view, new String[]{"SUM(from_amount)"},
+                andWhere(filter.getSelection(), "from_account_currency_id=" + toCurrency.id),
+                filter.getSelectionArgs(), null, null, null);
+        try {
+            if (hc.moveToFirst()) homeSum = hc.getLong(0);
+        } finally {
+            hc.close();
+        }
+        // slow path: remaining rows (need conversion) keep the per-row logic
+        Cursor c = db.db().query(view, HOME_CURRENCY_PROJECTION,
+                andWhere(filter.getSelection(), "from_account_currency_id!=" + toCurrency.id),
+                filter.getSelectionArgs(), null, null, null);
         try {
             try {
-                long balance = calculateTotalFromCursor(db, c, toCurrency);
+                BigDecimal converted = calculateTotalFromCursor(db, c, toCurrency);
                 Total total = new Total(toCurrency);
-                total.balance = balance;
+                total.balance = BigDecimal.valueOf(homeSum).add(converted).longValue();
+                Log.d("Financisto", "getBalanceInHomeCurrency " + (System.currentTimeMillis() - t0)
+                        + "ms (converted rows=" + c.getCount() + ")");
                 return total;
             } catch (UnableToCalculateRateException e) {
                 return new Total(e.toCurrency, TotalError.atDateRateError(e.fromCurrency, e.datetime));
@@ -134,13 +162,17 @@ public class TransactionsTotalCalculator {
         }
     }
 
-    private static long calculateTotalFromCursor(DatabaseAdapter db, Cursor c, Currency toCurrency) throws UnableToCalculateRateException {
+    private static String andWhere(String where, String cond) {
+        return (where == null || where.isEmpty()) ? cond : "(" + where + ") AND " + cond;
+    }
+
+    private static BigDecimal calculateTotalFromCursor(DatabaseAdapter db, Cursor c, Currency toCurrency) throws UnableToCalculateRateException {
         ExchangeRateProvider rates = db.getLatestRates();
         BigDecimal balance = BigDecimal.ZERO;
         while (c.moveToNext()) {
             balance = balance.add(getAmountFromCursor(db, c, toCurrency, rates, 0));
         }
-        return balance.longValue();
+        return balance;
     }
 
     public static Total calculateTotalFromListInHomeCurrency(DatabaseAdapter db, List<TransactionInfo> list) {

--- a/app/src/main/java/tw/tib/financisto/report/Report.java
+++ b/app/src/main/java/tw/tib/financisto/report/Report.java
@@ -92,20 +92,25 @@ public abstract class Report {
             ArrayList<GraphUnit> units = new ArrayList<GraphUnit>();
             GraphUnit u = null;
             long lastId = -1;
+            // getColumnIndex compares strings on every call; inside the loop that is three
+            // wasted lookups per row, and reports often have thousands of rows — resolve once
+            int isTransferIdx = c.getColumnIndex(ReportColumns.IS_TRANSFER);
+            int nameIdx = c.getColumnIndex(ReportColumns.NAME);
+            int datetimeIdx = c.getColumnIndex(ReportColumns.DATETIME);
             while (c.moveToNext()) {
                 long id = getId(c);
-                long isTransfer = c.getLong(c.getColumnIndex(ReportColumns.IS_TRANSFER));
+                long isTransfer = c.getLong(isTransferIdx);
                 if (id != lastId) {
                     if (u != null) {
                         units.add(u);
                     }
-                    String name = c.getString(c.getColumnIndex(ReportColumns.NAME));
+                    String name = c.getString(nameIdx);
                     u = new GraphUnit(id, alterName(id, name), currency, style);
                     lastId = id;
                 }
                 BigDecimal amount;
                 try {
-                    amount = TransactionsTotalCalculator.getAmountFromCursor(db, c, currency, rates, c.getColumnIndex(ReportColumns.DATETIME));
+                    amount = TransactionsTotalCalculator.getAmountFromCursor(db, c, currency, rates, datetimeIdx);
                 } catch (UnableToCalculateRateException e) {
                     amount = BigDecimal.ZERO;
                     u.error = TotalError.atDateRateError(e.fromCurrency, e.datetime);

--- a/app/src/main/java/tw/tib/financisto/report/SubCategoryReport.java
+++ b/app/src/main/java/tw/tib/financisto/report/SubCategoryReport.java
@@ -64,12 +64,15 @@ public class SubCategoryReport extends Report {
         final ExchangeRateProvider rates = db.getHistoryRates();
         try {
             final int leftColumnIndex = c.getColumnIndex(DatabaseHelper.SubCategoryReportColumns.LEFT);
+            // createNode is called per row and getColumnIndex compares strings —
+            // hoist it out of the loop (same as Report.getUnitsFromCursor)
+            final int datetimeIndex = c.getColumnIndex(DatabaseHelper.ReportColumns.DATETIME);
             CategoryTree<CategoryAmount> amounts = CategoryTree.createFromCursor(c, new NodeCreator<CategoryAmount>(){
                 @Override
                 public CategoryAmount createNode(Cursor c) {
                     BigDecimal amount;
                     try {
-                        amount = TransactionsTotalCalculator.getAmountFromCursor(db, c, currency, rates, c.getColumnIndex(DatabaseHelper.ReportColumns.DATETIME));
+                        amount = TransactionsTotalCalculator.getAmountFromCursor(db, c, currency, rates, datetimeIndex);
                     } catch (UnableToCalculateRateException e) {
                         amount = BigDecimal.ZERO;
                     }


### PR DESCRIPTION
As discussed in #121 (item 2).

`getBalanceInHomeCurrency` pulls every matching row into Java and converts them one by one with BigDecimal; on a ~25k-row blotter this makes the total bar noticeably slow, and it recalculates on every tab switch / save-return.

`getConvertedAmount`'s branch order guarantees that rows whose from-side currency equals the target currency always contribute `+from_amount` (to/original are never consulted for them), so this PR sums those rows directly in SQL and keeps the per-row conversion only for foreign-currency rows. For single-currency users the Java-side work drops to zero; `getAccountBalance` benefits via the same code path.

Equivalence: integer `SUM()` has no rounding, truncation still happens only at the final `longValue()`, and I verified the result is bit-identical to the row-by-row version against a real 21k-transaction database.

Also hoists `getColumnIndex` out of the row loops in `Report.getUnitsFromCursor` and `SubCategoryReport.createNode` (string comparison per call, thousands of rows per report).

Comments are in English per your note.