### PR TITLE
feat: auto-create transactions from Google Wallet payment notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ configurations.all {
 }
 
 dependencies {
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.0-alpha02'
     annotationProcessor "org.androidannotations:androidannotations:$AAVersion"
     implementation "org.androidannotations:androidannotations-api:$AAVersion"

--- a/app/src/main/java/tw/tib/financisto/service/FinancistoService.java
+++ b/app/src/main/java/tw/tib/financisto/service/FinancistoService.java
@@ -33,6 +33,7 @@ import tw.tib.financisto.db.DatabaseAdapter;
 import tw.tib.financisto.model.Transaction;
 import tw.tib.financisto.model.TransactionInfo;
 import tw.tib.financisto.model.TransactionStatus;
+import tw.tib.financisto.utils.MyPreferences;
 import tw.tib.financisto.utils.NotificationUtils;
 
 import static tw.tib.financisto.utils.MyPreferences.getSmsTransactionStatus;
@@ -45,12 +46,16 @@ public class FinancistoService extends JobIntentService {
     public static final String ACTION_NEW_TRANSACTION_SMS = "tw.tib.financisto.NEW_TRANSACTON_SMS";
     public static final String SMS_TRANSACTION_NUMBER = "SMS_TRANSACTION_NUMBER";
     public static final String SMS_TRANSACTION_BODY = "SMS_TRANSACTION_BODY";
+    public static final String ACTION_NEW_TRANSACTION_WALLET = "tw.tib.financisto.NEW_TRANSACTION_WALLET";
+    public static final String WALLET_TRANSACTION_TITLE = "WALLET_TRANSACTION_TITLE";
+    public static final String WALLET_TRANSACTION_TEXT = "WALLET_TRANSACTION_TEXT";
 
     private static final int RESTORED_NOTIFICATION_ID = 0;
 
     private DatabaseAdapter db;
     private RecurrenceScheduler scheduler;
     private SmsTransactionProcessor smsProcessor;
+    private GoogleWalletTransactionProcessor walletProcessor;
     private IntentTransactionProcessor intentTransactionProcessor;
 
     public static void enqueueWork(Context context, Intent work) {
@@ -64,6 +69,7 @@ public class FinancistoService extends JobIntentService {
         db.open();
         scheduler = new RecurrenceScheduler(db);
         smsProcessor = new SmsTransactionProcessor(db);
+        walletProcessor = new GoogleWalletTransactionProcessor(db);
         intentTransactionProcessor = new IntentTransactionProcessor(db);
     }
 
@@ -86,6 +92,9 @@ public class FinancistoService extends JobIntentService {
                 case ACTION_NEW_TRANSACTION_SMS:
                     processSmsTransaction(intent);
                     break;
+                case ACTION_NEW_TRANSACTION_WALLET:
+                    processWalletTransaction(intent);
+                    break;
             }
         }
     }
@@ -102,6 +111,33 @@ public class FinancistoService extends JobIntentService {
                 NotificationUtils.notifyUser(this, notification, (int) t.id);
                 AccountWidget.updateWidgets(this);
             }
+        }
+    }
+
+    private void processWalletTransaction(Intent intent) {
+        String title = intent.getStringExtra(WALLET_TRANSACTION_TITLE);
+        String text = intent.getStringExtra(WALLET_TRANSACTION_TEXT);
+        if (title == null) title = "";
+        if (text == null) text = "";
+        String notificationText = (title + " " + text).trim();
+
+        Transaction t = null;
+        GoogleWalletNotificationParser.ParsedPayment payment =
+                GoogleWalletNotificationParser.parse(title, text);
+        if (payment != null) {
+            t = walletProcessor.createTransaction(this, payment, notificationText,
+                    MyPreferences.getGoogleWalletTransactionStatus(), shouldSaveSmsToTransactionNote());
+        }
+        if (t == null) {
+            // fall back to user-defined notification templates matched by title
+            t = smsProcessor.createTransactionBySms(this, title, notificationText,
+                    getSmsTransactionStatus(), shouldSaveSmsToTransactionNote());
+        }
+        if (t != null) {
+            TransactionInfo transactionInfo = db.getTransactionInfo(t.id);
+            Notification notification = createWalletTransactionNotification(transactionInfo);
+            NotificationUtils.notifyUser(this, notification, (int) t.id);
+            AccountWidget.updateWidgets(this);
         }
     }
 
@@ -138,6 +174,14 @@ public class FinancistoService extends JobIntentService {
     private Notification createSmsTransactionNotification(TransactionInfo t, String number) {
         String tickerText = getString(R.string.new_sms_transaction_text, number);
         String contentTitle = getString(R.string.new_sms_transaction_title, number);
+        String text = t.getNotificationContentText(this);
+
+        return NotificationUtils.generateNotification(this, t, tickerText, contentTitle, text);
+    }
+
+    private Notification createWalletTransactionNotification(TransactionInfo t) {
+        String tickerText = getString(R.string.new_wallet_transaction_text);
+        String contentTitle = getString(R.string.new_wallet_transaction_title);
         String text = t.getNotificationContentText(this);
 
         return NotificationUtils.generateNotification(this, t, tickerText, contentTitle, text);

--- a/app/src/main/java/tw/tib/financisto/service/GoogleWalletNotificationParser.java
+++ b/app/src/main/java/tw/tib/financisto/service/GoogleWalletNotificationParser.java
@@ -1,0 +1,230 @@
+package tw.tib.financisto.service;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses Google Wallet tap-to-pay notifications into a payment.
+ *
+ * Depending on the Wallet version and locale, the amount/card line can be either
+ * in the notification title or in the text, with the merchant name in the other
+ * field, e.g.:
+ *   title="$4.50 with Visa •••• 1234", text="STARBUCKS"
+ *   title="McDonald's",                text="12,34 € · Mastercard •• 4321"
+ *
+ * This class is intentionally free of Android dependencies so it can be unit
+ * tested on the JVM.
+ */
+public class GoogleWalletNotificationParser {
+
+    /** Card reference like "•••• 1234", "••1234", "**** 1234", "xx1234" */
+    private static final Pattern CARD_PATTERN =
+            Pattern.compile("(?:[•∙●✱*]+|[xX]{2,})\\s*(\\d{4})\\b");
+
+    /** Common ISO 4217 codes — an explicit list avoids treating any 3-letter merchant word as a currency */
+    private static final String CURRENCY_ISO =
+            "USD|EUR|GBP|UAH|RUB|PLN|CZK|JPY|CNY|INR|TRY|KRW|BRL|CAD|AUD|CHF|SEK|NOK|DKK|"
+            + "HUF|RON|BGN|ILS|AED|SAR|KZT|GEL|MDL|HKD|SGD|NZD|ZAR|MXN|THB|BYN|GBX";
+
+    private static final String CURRENCY_MARKER =
+            "US\\$|R\\$|\\$|€|£|₴|₽|¥|₹|₺|₩|zł|Kč|грн\\.?|руб\\.?|(?<![A-Z])(?:" + CURRENCY_ISO + ")(?![A-Z])";
+
+    private static final String NUMBER =
+            "\\d{1,3}(?:[ \\u00A0\\u202F.,]?\\d{3})*(?:[.,]\\d{1,2})?";
+
+    /** An amount with a currency marker before or after it */
+    private static final Pattern MONEY_PATTERN = Pattern.compile(
+            "(?:(" + CURRENCY_MARKER + ")\\s?)?(" + NUMBER + ")(?:\\s?(" + CURRENCY_MARKER + "))?");
+
+    /** "$5.00 at Starbucks with Visa ••1234" — merchant embedded in the payment line */
+    private static final Pattern MERCHANT_IN_PAYMENT_LINE =
+            Pattern.compile("\\bat\\s+(.+?)(?=\\s+with\\b|\\s*$)", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * The card/payment method the notification says the payment was made "with".
+     * Wallet uses the English word "with" even in localized notifications, e.g.
+     * "UAH192.18 with Сільпо" or "UAH198.00 with Visa PrivatBank ••6810".
+     * A couple of localized connectors are matched defensively.
+     */
+    private static final Pattern CARD_LABEL_PATTERN = Pattern.compile(
+            "\\b(?:with|через|карткою|з карткою|con|mit|avec)\\s+(.+?)\\s*$",
+            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+
+    private static final Map<String, String> CURRENCY_BY_SYMBOL = new HashMap<>();
+    static {
+        CURRENCY_BY_SYMBOL.put("$", "USD");
+        CURRENCY_BY_SYMBOL.put("US$", "USD");
+        CURRENCY_BY_SYMBOL.put("€", "EUR");
+        CURRENCY_BY_SYMBOL.put("£", "GBP");
+        CURRENCY_BY_SYMBOL.put("₴", "UAH");
+        CURRENCY_BY_SYMBOL.put("грн", "UAH");
+        CURRENCY_BY_SYMBOL.put("грн.", "UAH");
+        CURRENCY_BY_SYMBOL.put("₽", "RUB");
+        CURRENCY_BY_SYMBOL.put("руб", "RUB");
+        CURRENCY_BY_SYMBOL.put("руб.", "RUB");
+        CURRENCY_BY_SYMBOL.put("¥", "JPY");
+        CURRENCY_BY_SYMBOL.put("₹", "INR");
+        CURRENCY_BY_SYMBOL.put("₺", "TRY");
+        CURRENCY_BY_SYMBOL.put("₩", "KRW");
+        CURRENCY_BY_SYMBOL.put("zł", "PLN");
+        CURRENCY_BY_SYMBOL.put("Kč", "CZK");
+        CURRENCY_BY_SYMBOL.put("R$", "BRL");
+    }
+
+    public static class ParsedPayment {
+        public BigDecimal amount;
+        /** ISO 4217 code, or null when the notification had no recognizable currency */
+        public String currency;
+        /** The card label as shown in Wallet, e.g. "Сільпо" or "Visa PrivatBank ••6810", or null */
+        public String cardLabel;
+        /** Last 4 digits of the card, when the label contains them, else null */
+        public String cardLast4;
+        public String merchant;
+    }
+
+    /**
+     * @return parsed payment, or null if the notification is not a payment
+     *         (e.g. "card added", loyalty pass updates etc.)
+     */
+    public static ParsedPayment parse(String title, String text) {
+        title = title == null ? "" : title.trim();
+        text = text == null ? "" : text.trim();
+
+        Money titleMoney = findMoney(title);
+        Money textMoney = findMoney(text);
+
+        String paymentLine;
+        String merchantLine;
+        Money money;
+        if (titleMoney != null && textMoney != null) {
+            // both fields look like an amount (e.g. a merchant name with digits) —
+            // prefer the field that carries the payment: the "with <card>" connector
+            // is the strongest signal, then a card mask
+            int titleScore = paymentLineScore(title);
+            int textScore = paymentLineScore(text);
+            if (textScore > titleScore) {
+                titleMoney = null;
+            } else if (titleScore > textScore) {
+                textMoney = null;
+            }
+        }
+        if (titleMoney != null) {
+            money = titleMoney;
+            paymentLine = title;
+            merchantLine = text;
+        } else if (textMoney != null) {
+            money = textMoney;
+            paymentLine = text;
+            merchantLine = title;
+        } else {
+            return null;
+        }
+
+        ParsedPayment payment = new ParsedPayment();
+        payment.amount = money.amount;
+        payment.currency = money.currency;
+        payment.cardLabel = extractCardLabel(paymentLine);
+        payment.cardLast4 = findCardLast4(payment.cardLabel != null ? payment.cardLabel : "", title, text);
+        payment.merchant = extractMerchant(merchantLine, paymentLine);
+        return payment;
+    }
+
+    /** Higher score = more likely to be the payment line rather than the merchant line */
+    private static int paymentLineScore(String s) {
+        int score = 0;
+        if (CARD_LABEL_PATTERN.matcher(s).find()) {
+            score += 2;
+        }
+        if (CARD_PATTERN.matcher(s).find()) {
+            score += 1;
+        }
+        return score;
+    }
+
+    private static String extractCardLabel(String paymentLine) {
+        Matcher m = CARD_LABEL_PATTERN.matcher(paymentLine);
+        if (m.find()) {
+            String label = m.group(1).trim();
+            // drop a trailing separator dot Wallet sometimes appends, keep card-mask dots
+            label = label.replaceAll("\\s*[·・]\\s*$", "").trim();
+            if (!label.isEmpty()) {
+                return label;
+            }
+        }
+        return null;
+    }
+
+    private static class Money {
+        BigDecimal amount;
+        String currency;
+    }
+
+    private static Money findMoney(String s) {
+        if (s.isEmpty()) {
+            return null;
+        }
+        Matcher m = MONEY_PATTERN.matcher(s);
+        while (m.find()) {
+            String marker = m.group(1) != null ? m.group(1) : m.group(3);
+            // a bare number (e.g. card digits) is not an amount
+            if (marker == null) {
+                continue;
+            }
+            try {
+                Money money = new Money();
+                money.amount = SmsTransactionProcessor.toBigDecimal(m.group(2));
+                money.currency = toCurrencyCode(marker);
+                return money;
+            } catch (NumberFormatException ignored) {
+                // keep looking
+            }
+        }
+        return null;
+    }
+
+    private static String toCurrencyCode(String marker) {
+        String code = CURRENCY_BY_SYMBOL.get(marker);
+        if (code != null) {
+            return code;
+        }
+        if (marker.matches("[A-Z]{3}")) {
+            return marker;
+        }
+        return null;
+    }
+
+    private static String findCardLast4(String... candidates) {
+        for (String s : candidates) {
+            if (s == null) {
+                continue;
+            }
+            Matcher m = CARD_PATTERN.matcher(s);
+            if (m.find()) {
+                return m.group(1);
+            }
+        }
+        return null;
+    }
+
+    private static String extractMerchant(String merchantLine, String paymentLine) {
+        String merchant = merchantLine.trim();
+        if (merchant.regionMatches(true, 0, "at ", 0, 3)) {
+            merchant = merchant.substring(3).trim();
+        }
+        if (merchant.isEmpty()
+                || merchant.equalsIgnoreCase("Google Wallet")
+                || merchant.equalsIgnoreCase("Google Pay")
+                || merchant.equalsIgnoreCase("Гаманець Google")) {
+            // no separate merchant field, it may be embedded in the payment line
+            Matcher m = MERCHANT_IN_PAYMENT_LINE.matcher(paymentLine);
+            if (m.find()) {
+                return m.group(1).trim();
+            }
+            return null;
+        }
+        return merchant;
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/service/GoogleWalletTransactionProcessor.java
+++ b/app/src/main/java/tw/tib/financisto/service/GoogleWalletTransactionProcessor.java
@@ -1,0 +1,143 @@
+package tw.tib.financisto.service;
+
+import static java.lang.String.format;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import tw.tib.financisto.db.DatabaseAdapter;
+import tw.tib.financisto.model.Account;
+import tw.tib.financisto.model.Payee;
+import tw.tib.financisto.model.Transaction;
+import tw.tib.financisto.model.TransactionStatus;
+import tw.tib.financisto.service.GoogleWalletNotificationParser.ParsedPayment;
+
+/**
+ * Creates an expense transaction from a parsed Google Wallet payment notification.
+ * The account is resolved by the card last 4 digits against the account card
+ * number field (same matching as the SMS template <:A:> placeholder).
+ */
+public class GoogleWalletTransactionProcessor {
+    private static final String TAG = "GoogleWalletProcessor";
+    private static final BigDecimal HUNDRED = new BigDecimal(100);
+
+    private final DatabaseAdapter db;
+
+    public GoogleWalletTransactionProcessor(DatabaseAdapter db) {
+        this.db = db;
+    }
+
+    public Transaction createTransaction(Context context, ParsedPayment payment,
+            String notificationText, TransactionStatus status, boolean saveNotificationToNote)
+    {
+        long accountId = findAccount(payment);
+        if (accountId <= 0) {
+            // No matching account: skip silently. Do NOT create a log transaction
+            // here — db.log() would insert a zero-amount entry into the first
+            // account, which for Wallet (where every payment notification is
+            // processed) would spam junk transactions.
+            Log.w(TAG, format("No account matches Wallet card `%s` (last4=%s), skipping",
+                    payment.cardLabel, payment.cardLast4));
+            return null;
+        }
+
+        Transaction t = new Transaction();
+        t.isTemplate = 0;
+        t.fromAccountId = accountId;
+
+        if (payment.merchant != null) {
+            Payee payee = db.findOrInsertEntityByTitle(Payee.class, payment.merchant);
+            t.payeeId = payee.id;
+            t.categoryId = payee.lastCategoryId;
+        }
+
+        long fromAmount = -Math.abs(payment.amount.multiply(HUNDRED).longValue());
+        if (payment.currency != null) {
+            long currencyId = db.findCurrencyByName(payment.currency);
+            if (currencyId != 0) {
+                Account a = db.getAccount(accountId);
+                if (a.currency.id != currencyId) {
+                    t.originalCurrencyId = currencyId;
+                    t.originalFromAmount = fromAmount;
+                }
+            }
+        }
+        if (t.originalCurrencyId == 0) {
+            t.fromAmount = fromAmount;
+        }
+
+        if (saveNotificationToNote) {
+            t.note = notificationText;
+        } else {
+            t.note = payment.merchant != null ? payment.merchant : "";
+        }
+        t.status = status;
+        t.id = db.insertOrUpdate(t);
+
+        Log.i(TAG, format("Google Wallet transaction `%s` was added with id=%s", t, t.id));
+        return t;
+    }
+
+    /**
+     * Resolves the Financisto account for a Wallet card. Primary matching is by
+     * account name (the user names the account like the Wallet card label), with
+     * fallbacks to the card last-4 digits and a substring match on the account
+     * card-number field.
+     */
+    private long findAccount(ParsedPayment payment) {
+        String label = payment.cardLabel != null ? payment.cardLabel.trim() : "";
+
+        // 1. last 4 digits (e.g. "Visa PrivatBank ••6810") against the card-number field
+        if (payment.cardLast4 != null && !payment.cardLast4.isEmpty()) {
+            long id = firstOrNone(db.findAccountsByNumber(payment.cardLast4),
+                    "card ending " + payment.cardLast4);
+            if (id > 0) {
+                return id;
+            }
+        }
+
+        if (!label.isEmpty()) {
+            // 2. account title equal to the card label (exact, then case-insensitive)
+            long id = db.getEntityIdByTitle(Account.class, label);
+            if (id > 0) {
+                return id;
+            }
+            List<Account> accounts = db.getAllAccountsList();
+            for (Account a : accounts) {
+                if (a.title != null && a.title.trim().equalsIgnoreCase(label)) {
+                    return a.id;
+                }
+            }
+
+            // 3. card-number field contains the label
+            id = firstOrNone(db.findAccountsByNumber(label), "card label " + label);
+            if (id > 0) {
+                return id;
+            }
+
+            // 4. account title contained in the label, e.g. account "PrivatBank"
+            //    matches "Visa PrivatBank ••6810" (guarded to avoid trivial matches)
+            String labelLc = label.toLowerCase();
+            for (Account a : accounts) {
+                String title = a.title != null ? a.title.trim() : "";
+                if (title.length() >= 3 && labelLc.contains(title.toLowerCase())) {
+                    return a.id;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private long firstOrNone(List<Long> accountIds, String what) {
+        if (accountIds == null || accountIds.isEmpty()) {
+            return -1;
+        }
+        if (accountIds.size() > 1) {
+            Log.e(TAG, format("More than one account matches %s", what));
+        }
+        return accountIds.get(0);
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
+++ b/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
@@ -1,8 +1,11 @@
 package tw.tib.financisto.service;
 
 import static tw.tib.financisto.service.FinancistoService.ACTION_NEW_TRANSACTION_SMS;
+import static tw.tib.financisto.service.FinancistoService.ACTION_NEW_TRANSACTION_WALLET;
 import static tw.tib.financisto.service.FinancistoService.SMS_TRANSACTION_BODY;
 import static tw.tib.financisto.service.FinancistoService.SMS_TRANSACTION_NUMBER;
+import static tw.tib.financisto.service.FinancistoService.WALLET_TRANSACTION_TEXT;
+import static tw.tib.financisto.service.FinancistoService.WALLET_TRANSACTION_TITLE;
 
 import android.app.Notification;
 import android.content.Context;
@@ -13,14 +16,24 @@ import android.service.notification.StatusBarNotification;
 import android.text.SpannableString;
 import android.util.Log;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import tw.tib.financisto.db.DatabaseAdapter;
 import tw.tib.financisto.model.SmsTemplate;
+import tw.tib.financisto.utils.MyPreferences;
 
 public class NotificationListener extends NotificationListenerService {
     private static final String TAG = "NotificationListener";
+
+    private static final Set<String> GOOGLE_WALLET_PACKAGES = new HashSet<>(Arrays.asList(
+            // Google Wallet
+            "com.google.android.apps.walletnfcrel",
+            // Google Pay (India)
+            "com.google.android.apps.nbu.paisa.user"));
+
     private String packageName;
     private NotificationCache notificationCache;
 
@@ -84,6 +97,16 @@ public class NotificationListener extends NotificationListenerService {
             Log.d(TAG, sbn.getNotification().extras.toString());
 
             if (processTemplate && (existing == null || !body.equals(existing.body))) {
+                if (GOOGLE_WALLET_PACKAGES.contains(packageName)
+                        && MyPreferences.isGoogleWalletTransactionEnabled())
+                {
+                    Intent serviceIntent = new Intent(ACTION_NEW_TRANSACTION_WALLET, null, context, FinancistoService.class);
+                    serviceIntent.putExtra(WALLET_TRANSACTION_TITLE, title);
+                    serviceIntent.putExtra(WALLET_TRANSACTION_TEXT, notification.text);
+                    FinancistoService.enqueueWork(context, serviceIntent);
+                    return;
+                }
+
                 final DatabaseAdapter db = new DatabaseAdapter(context);
                 List<SmsTemplate> templates = db.getSmsTemplatesByNumber(title);
 
@@ -116,6 +139,7 @@ public class NotificationListener extends NotificationListenerService {
                 }
                 sb.append(bigText);
             }
+            result.text = sb.toString();
             result.body = result.title + " " + sb;
         }
         return result;
@@ -124,6 +148,7 @@ public class NotificationListener extends NotificationListenerService {
     public static class ParsedNotification {
         public String key;
         public String title;
+        public String text;
         public String body;
     }
 

--- a/app/src/main/java/tw/tib/financisto/utils/MyPreferences.java
+++ b/app/src/main/java/tw/tib/financisto/utils/MyPreferences.java
@@ -816,6 +816,14 @@ public class MyPreferences {
 		return getBoolean("sms_transaction_note", true);
 	}
 
+	public static boolean isGoogleWalletTransactionEnabled() {
+		return getBoolean("google_wallet_transaction", false);
+	}
+
+	public static TransactionStatus getGoogleWalletTransactionStatus() {
+		return TransactionStatus.valueOf(getString("google_wallet_transaction_status", "PN"));
+	}
+
 	public static long getLastAutobackupCheck() {
 		return getLong("last_autobackup_check", 0);
 	}

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -1045,6 +1045,13 @@
     <string name="pref_tpl_transaction_status">Статус транзакції, створений із шаблону: %s</string>
     <string name="pref_tpl_adding_to_note_title">Збереження тексту сповіщення</string>
     <string name="pref_tpl_adding_to_note">Додавати текст сповіщення до примітки транзакції</string>
+    <string name="pref_google_wallet">Google Wallet</string>
+    <string name="pref_google_wallet_transaction_title">Створювати транзакції з Google Wallet</string>
+    <string name="pref_google_wallet_transaction_summary">Автоматично створювати транзакцію, коли з\'являється сповіщення про оплату Google Wallet. Потрібен доступ до сповіщень. Рахунок визначається за назвою: назвіть рахунок Financisto так само, як картка у сповіщенні після слова \"with\" (напр. \"Сільпо\"). Також підходять збіг за номером картки, рахунок із цими 4 цифрами в полі номера картки або назва рахунку, що міститься в мітці картки.</string>
+    <string name="pref_google_wallet_transaction_status">Статус транзакції, створеної зі сповіщення Google Wallet: %s</string>
+    <string name="new_wallet_transaction_text">Нова транзакція додана з Google Wallet</string>
+    <string name="new_wallet_transaction_title">Транзакція Google Wallet</string>
+    <string name="google_wallet_error_log">Жоден рахунок Financisto не відповідає картці Google Wallet `%s`. Назвіть рахунок так само, як картка, або вкажіть останні 4 цифри картки в полі номера картки рахунку.</string>
     <string name="sms_tpl_list_category_payee_project_name">%1$s, %2$s, %3$s</string>
 
     <string name="card_issuer_default">За замовчуванням</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1118,6 +1118,13 @@
     <string name="pref_tpl_adding_to_note">Add notification text to transaction note</string>
     <string name="sms_tpl_list_category_payee_project_name">%1$s, %2$s, %3$s</string>
     <string name="sms_tpl_error_log">Account not found or cannot parse price for notification template from sender `%1$s`, template `%2$s`, content `%3$s`</string>
+    <string name="pref_google_wallet">Google Wallet</string>
+    <string name="pref_google_wallet_transaction_title">Create transactions from Google Wallet</string>
+    <string name="pref_google_wallet_transaction_summary">Automatically create a transaction when a Google Wallet payment notification appears. Requires notification access. The account is matched by name: name a Financisto account the same as the card shown after \"with\" in the notification (e.g. \"Сільпо\"). A card number, an account whose card number field contains the last 4 digits, or an account name contained in the card label also match.</string>
+    <string name="pref_google_wallet_transaction_status">Status of transaction created from Google Wallet notification: %s</string>
+    <string name="new_wallet_transaction_text">New transaction added from Google Wallet</string>
+    <string name="new_wallet_transaction_title">Google Wallet transaction</string>
+    <string name="google_wallet_error_log">No Financisto account matches the Google Wallet card `%s`. Name an account the same as the card, or put the card\'s last 4 digits in the account card number field.</string>
 
     <string name="card_issuer_default">Default</string>
     <string name="electronic_payment_type">Payment type</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -64,6 +64,22 @@
             android:title="@string/pref_tpl_adding_to_note_title" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/pref_google_wallet">
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="google_wallet_transaction"
+            android:summary="@string/pref_google_wallet_transaction_summary"
+            android:title="@string/pref_google_wallet_transaction_title" />
+        <ListPreference
+            android:defaultValue="PN"
+            android:dependency="google_wallet_transaction"
+            android:entries="@array/pref_transaction_statuses"
+            android:entryValues="@array/pref_transaction_status_values"
+            android:key="google_wallet_transaction_status"
+            android:summary="@string/pref_google_wallet_transaction_status"
+            android:title="@string/pref_tpl_transaction_status_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/protection">
         <SwitchPreferenceCompat
             android:defaultValue="true"

--- a/app/src/test/java/tw/tib/financisto/service/GoogleWalletNotificationParserTest.java
+++ b/app/src/test/java/tw/tib/financisto/service/GoogleWalletNotificationParserTest.java
@@ -1,0 +1,159 @@
+package tw.tib.financisto.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import tw.tib.financisto.service.GoogleWalletNotificationParser.ParsedPayment;
+
+public class GoogleWalletNotificationParserTest {
+
+    @Test
+    public void amountInTitle_merchantInText() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "$4.50 with Visa •••• 1234", "STARBUCKS");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("4.50"), p.amount);
+        assertEquals("USD", p.currency);
+        assertEquals("1234", p.cardLast4);
+        assertEquals("STARBUCKS", p.merchant);
+        assertEquals("Visa •••• 1234", p.cardLabel);
+    }
+
+    // Real Google Wallet format observed on a UA device:
+    // title = merchant, text = "<CUR><amount> with <card>"
+
+    @Test
+    public void realFormat_namedCard() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "VM33", "UAH192.18 with Сільпо");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("192.18"), p.amount);
+        assertEquals("UAH", p.currency);
+        assertEquals("VM33", p.merchant);
+        assertEquals("Сільпо", p.cardLabel);
+        assertNull(p.cardLast4);
+    }
+
+    @Test
+    public void realFormat_namedCardWithMerchant() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "SILPO", "UAH189.95 with Сільпо");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("189.95"), p.amount);
+        assertEquals("UAH", p.currency);
+        assertEquals("SILPO", p.merchant);
+        assertEquals("Сільпо", p.cardLabel);
+    }
+
+    @Test
+    public void realFormat_cardWithLast4() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "SILPO", "UAH198.00 with Visa PrivatBank ••6810");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("198.00"), p.amount);
+        assertEquals("UAH", p.currency);
+        assertEquals("SILPO", p.merchant);
+        assertEquals("Visa PrivatBank ••6810", p.cardLabel);
+        assertEquals("6810", p.cardLast4);
+    }
+
+    @Test
+    public void merchantInTitle_amountInText() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "McDonald's", "12,34 € · Mastercard •• 4321");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("12.34"), p.amount);
+        assertEquals("EUR", p.currency);
+        assertEquals("4321", p.cardLast4);
+        assertEquals("McDonald's", p.merchant);
+    }
+
+    @Test
+    public void ukrainianHryvnia() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "123,45 грн через Visa •••• 9876", "СІЛЬПО");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("123.45"), p.amount);
+        assertEquals("UAH", p.currency);
+        assertEquals("9876", p.cardLast4);
+        assertEquals("СІЛЬПО", p.merchant);
+    }
+
+    @Test
+    public void hryvniaSymbol() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "₴1 234,56 · Mastercard •••• 1111", "АТБ-МАРКЕТ");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("1234.56"), p.amount);
+        assertEquals("UAH", p.currency);
+        assertEquals("1111", p.cardLast4);
+        assertEquals("АТБ-МАРКЕТ", p.merchant);
+    }
+
+    @Test
+    public void isoCurrencyCode() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "25.00 PLN with Visa •••• 2222", "Żabka");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("25.00"), p.amount);
+        assertEquals("PLN", p.currency);
+        assertEquals("2222", p.cardLast4);
+    }
+
+    @Test
+    public void merchantEmbeddedInPaymentLine() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "$5.00 at Starbucks with Visa •••• 1234", "");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("5.00"), p.amount);
+        assertEquals("Starbucks", p.merchant);
+        assertEquals("1234", p.cardLast4);
+    }
+
+    @Test
+    public void appNameIsNotMerchant() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "Google Wallet", "$3.00 with Visa •••• 1234");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("3.00"), p.amount);
+        assertNull(p.merchant);
+    }
+
+    @Test
+    public void nonPaymentNotificationIsIgnored() {
+        assertNull(GoogleWalletNotificationParser.parse(
+                "Google Wallet", "Card was added to your device"));
+    }
+
+    @Test
+    public void bareCardDigitsAreNotAnAmount() {
+        assertNull(GoogleWalletNotificationParser.parse(
+                "Visa •••• 1234", "Contactless setup complete"));
+    }
+
+    @Test
+    public void merchantWithDigitsInTitle_paymentInText() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "WOG 555", "75.00 UAH with Visa •••• 3333");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("75.00"), p.amount);
+        assertEquals("UAH", p.currency);
+        assertEquals("3333", p.cardLast4);
+        assertEquals("WOG 555", p.merchant);
+    }
+
+    @Test
+    public void noCardDigitsStillParses() {
+        ParsedPayment p = GoogleWalletNotificationParser.parse(
+                "$7.25 with Visa", "TARGET");
+        assertNotNull(p);
+        assertEquals(new BigDecimal("7.25"), p.amount);
+        assertNull(p.cardLast4);
+        assertEquals("TARGET", p.merchant);
+    }
+}


### PR DESCRIPTION
## What

Adds an option to **automatically create a transaction from a Google Wallet payment notification**, without needing a notification template. It complements the existing notification-template feature, which matches on the notification *title* — that doesn't fit Google Wallet, where the title is the (varying) merchant name.

## Why

Google Wallet posts a notification on every tap-to-pay. Turning those into transactions automatically removes manual entry for card spending.

## How it works

Google Wallet posts payment notifications as `title = merchant`, `text = <amount> with <card>` (the English word "with" is used even in localized notifications), e.g.:

- `SILPO` / `UAH192.18 with Сільпо`
- `SILPO` / `UAH198.00 with Visa PrivatBank ••6810`

- **`NotificationListener`** forwards notifications from the Google Wallet / Google Pay packages to a dedicated processor, gated by a new preference.
- **`GoogleWalletNotificationParser`** (no Android deps, unit-tested) extracts the amount, ISO currency (symbols + known ISO codes), the card label after "with", the last-4 digits when present, and the merchant.
- **`GoogleWalletTransactionProcessor`** resolves the account **by name** — the account title equals the card label — with fallbacks to the card last-4 digits and a substring match on the account *card number* field, then creates an expense with the merchant as payee. **If no account matches, it skips (no transaction is created).**
- New **Settings → Google Wallet** category: an enable toggle and a transaction-status picker. Strings localized in English and Ukrainian.

## Configuration (for users)

1. Enable *Settings → Google Wallet → Create transactions from Google Wallet*.
2. Grant notification access.
3. Match the account: name a Financisto account the same as the Wallet card (the text after "with"), or put the card's last-4 digits in the account *card number* field.

## Testing

- Unit tests for the parser (`GoogleWalletNotificationParserTest`, 14 cases incl. UAH/hryvnia formats, named cards, ISO codes, non-payment notifications).
- Verified end-to-end on a real device (Galaxy S24 Ultra): a real Wallet payment created the correct expense in the matched account with the merchant as payee.

## Notes

- Adds `testImplementation 'junit:junit:4.13.2'` for the new unit test.
- Feature is **off by default**.
- Currency detection is limited to symbols + a known ISO-code list to avoid treating 3-letter merchant names as currencies.
