### PR TITLE
fix: {{x}} does not match account titles containing punctuation

### DIFF
--- a/app/src/androidTest/java/tw/tib/financisto/service/PlaceholderCaptureTest.java
+++ b/app/src/androidTest/java/tw/tib/financisto/service/PlaceholderCaptureTest.java
@@ -1,0 +1,64 @@
+package tw.tib.financisto.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import tw.tib.financisto.service.SmsTransactionProcessor.Placeholder;
+
+/**
+ * Runs on a device/emulator on purpose: Android's java.util.regex is ICU-backed and its
+ * character classes are always Unicode, which differs from a desktop JVM. A desktop unit
+ * test would give the wrong answer about what these placeholders capture.
+ *
+ * What matters here is not whether the template matches, but what it captures — a wrong
+ * capture is worse than no match, because the account lookup then silently fails.
+ */
+@RunWith(AndroidJUnit4.class)
+public class PlaceholderCaptureTest {
+
+    private static final String TEMPLATE = "transfer {{p}} to {{x}} done";
+
+    private static String captureTransferTo(String accountTitle) {
+        String[] match = SmsTransactionProcessor.findTemplateMatches(
+                TEMPLATE, "transfer 100 to " + accountTitle + " done");
+        assertNotNull("template did not match for: " + accountTitle, match);
+        return match[Placeholder.TRANSFER_TO_ACCOUNT_NAME.ordinal()];
+    }
+
+    @Test
+    public void capturesAsciiAccountTitle() {
+        assertEquals("LineBank", captureTransferTo("LineBank"));
+    }
+
+    @Test
+    public void capturesCjkAccountTitle() {
+        assertEquals("身上現金", captureTransferTo("身上現金"));
+        assertEquals("中信信用卡", captureTransferTo("中信信用卡"));
+        assertEquals("Richart帳戶", captureTransferTo("Richart帳戶"));
+    }
+
+    /**
+     * A hyphen is not a word character in any Unicode mode, so with (\w+?) the whole
+     * template fails to match and no transaction is created at all. This has nothing to
+     * do with the script the title is written in — plain ASCII titles break the same way.
+     */
+    @Test
+    public void capturesAccountTitleWithHyphen() {
+        assertEquals("Visa-Gold", captureTransferTo("Visa-Gold"));
+        assertEquals("郵局-老婆", captureTransferTo("郵局-老婆"));
+        assertEquals("富邦銀行-老婆", captureTransferTo("富邦銀行-老婆"));
+    }
+
+    /** Same for parentheses, which are punctuation rather than word characters. */
+    @Test
+    public void capturesAccountTitleWithParentheses() {
+        assertEquals("Cash(Joint)", captureTransferTo("Cash(Joint)"));
+        assertEquals("(存款)", captureTransferTo("(存款)"));
+        assertEquals("(旅遊儲蓄金)", captureTransferTo("(旅遊儲蓄金)"));
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/service/SmsTransactionProcessor.java
+++ b/app/src/main/java/tw/tib/financisto/service/SmsTransactionProcessor.java
@@ -366,7 +366,13 @@ public class SmsTransactionProcessor {
         PROJECT("<:R:>", "(\\S+?)", "{{r}}"),
         TEXT("<:T:>", "(.*?)", "{{t}}"),
         GREEDY_TEXT("<:U:>", "(.*)", "{{u}}"),
-        TRANSFER_TO_ACCOUNT_NAME("<:X:>", "(\\w+?)", "{{x}}");
+        // (\w+?) fails on account titles containing punctuation such as "-" or "()":
+        // those are not word characters, so the template does not match at all and no
+        // transaction is created. Use (\S+?), consistent with ACCOUNT_NAME / PAYEE /
+        // PROJECT above; \S is a superset of \w, so existing templates keep working.
+        // Covered by PlaceholderCaptureTest in androidTest — it has to run on a device,
+        // because Android's regex is ICU-backed and a desktop JVM answers differently.
+        TRANSFER_TO_ACCOUNT_NAME("<:X:>", "(\\S+?)", "{{x}}");
 
         public String code;
         public String regexp;


### PR DESCRIPTION
**Rewritten after your review — the original claim was wrong, sorry for the noise. The `UNICODE_CHARACTER_CLASS` change is dropped and only the `\S` part remains, now with a device test behind it.**

### What was wrong with the first version

I verified on a desktop JDK 21 and assumed it carried over to Android. It does not — as you pointed out, Android's regex always uses Unicode character classes, so `\w` does match CJK and the flag is neither needed nor supported. The `GoogleWalletNotificationParser` half of this PR was therefore invalid and has been removed.

### What actually breaks

Punctuation, not script. `-`, `(` and `)` are not word characters in any Unicode mode, so `(\w+?)` cannot match an account title that contains them — and because the placeholder sits between literal text, the **whole template fails to match**, so no transaction is created at all.

This is not a CJK problem: a plain ASCII title like `Visa-Gold` or `Cash(Joint)` breaks identically.

Measured on an API 35 emulator with the added `androidTest`:

| account title | `(\w+?)` | `(\S+?)` |
|---|---|---|
| `LineBank` | ok | ok |
| `身上現金` | ok | ok |
| `中信信用卡` | ok | ok |
| `Richart帳戶` | ok | ok |
| `Visa-Gold` | **no match** | ok |
| `Cash(Joint)` | **no match** | ok |
| `郵局-老婆` | **no match** | ok |
| `(存款)` | **no match** | ok |

`\S` is a superset of `\w`, so existing templates keep working. `\S` itself needs no flag and is available on API 23, so this is safe for the Android 6.0 users you mentioned.

### The test

`app/src/androidTest/.../PlaceholderCaptureTest.java` — 4 tests, asserting **what the placeholder captures**, not merely whether the template matches. It has to be an instrumented test: Android's `java.util.regex` is ICU-backed and a desktop JVM answers differently for exactly these inputs, which is how I got it wrong the first time. There was no `androidTest` source set before; adding it uses dependencies you already declare.

`connectedDebugAndroidTest` on `fin35 (API 35)`: the two punctuation tests fail before the change, all four pass after.

Happy to drop the test if you would rather not carry an `androidTest` source set — the one-word fix stands on its own.
