### PR TITLE
fix: order the notification list by post time

### DIFF
--- a/app/src/main/java/tw/tib/financisto/activity/NotificationListActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/NotificationListActivity.java
@@ -19,6 +19,7 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 import tw.tib.financisto.R;
 import tw.tib.financisto.service.NotificationCache;
@@ -67,6 +68,10 @@ public class NotificationListActivity extends AppCompatActivity {
 
         public NotificationListAdapter(Context context) {
             list = new ArrayList<>(NotificationCache.getInstance().cache.values());
+            // The cache is a HashMap, so its iteration order is bucket order: the list
+            // comes out in no meaningful order and can reshuffle when a notification is
+            // added. Show newest first instead.
+            Collections.sort(list, (a, b) -> Long.compare(b.postTime, a.postTime));
             inflater = LayoutInflater.from(context);
         }
 

--- a/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
+++ b/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
@@ -127,6 +127,7 @@ public class NotificationListener extends NotificationListenerService {
             StringBuilder sb = new StringBuilder();
             result = new ParsedNotification();
             result.key = sbn.getKey();
+            result.postTime = sbn.getPostTime();
             result.title = getString(extras.getCharSequence(Notification.EXTRA_TITLE));
             String text = getString(extras.getCharSequence(Notification.EXTRA_TEXT));
             if (text != null) {
@@ -150,6 +151,8 @@ public class NotificationListener extends NotificationListenerService {
         public String title;
         public String text;
         public String body;
+        /** When the notification was posted; used to order the notification list. */
+        public long postTime;
     }
 
     private static String getString(Object s) {


### PR DESCRIPTION
`NotificationListAdapter` builds its list straight from `NotificationCache`, which is a `HashMap`:

```java
list = new ArrayList<>(NotificationCache.getInstance().cache.values());
```

So the rows come out in hash bucket order — not by time, not grouped by app — and the order can change when a notification is added or removed. There is no `sort` anywhere, so the screen just looks like its sorting is broken.

This records `StatusBarNotification.getPostTime()` on `ParsedNotification` and sorts newest first. No behaviour change other than the ordering.

Built and verified with `assembleDebug`.
