### PR TITLE
feat: try to rebind the notification listener when it gets unbound

### DIFF
--- a/app/src/main/java/tw/tib/financisto/Application.java
+++ b/app/src/main/java/tw/tib/financisto/Application.java
@@ -35,6 +35,9 @@ public class Application extends MultiDexApplication {
         instance = this;
         executor = Executors.newCachedThreadPool();
         copiedUneditedTransactions = new Long2LongOpenHashMap();
+        // the MY_PACKAGE_REPLACED broadcast does not always manage to rebind the
+        // notification listener; opening the app is the other natural moment to retry
+        tw.tib.financisto.service.NotificationListener.requestRebindIfGranted(this);
 
         if (BuildConfig.DEBUG) {
             StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()

--- a/app/src/main/java/tw/tib/financisto/activity/NotificationListActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/NotificationListActivity.java
@@ -47,6 +47,10 @@ public class NotificationListActivity extends AppCompatActivity {
             return WindowInsetsCompat.CONSUMED;
         });
 
+        // opening this screen is what a user does when notifications stopped arriving,
+        // so let it heal a listener the system silently unbound
+        NotificationListener.requestRebindIfGranted(this);
+
         list = findViewById(android.R.id.list);
         list.setAdapter(new NotificationListAdapter(this));
         list.setOnItemClickListener((adapterView, view, i, l) -> {

--- a/app/src/main/java/tw/tib/financisto/activity/PackageReplaceReceiver.java
+++ b/app/src/main/java/tw/tib/financisto/activity/PackageReplaceReceiver.java
@@ -17,6 +17,7 @@ import android.util.Log;
 
 import tw.tib.financisto.service.DailyAutoBackupScheduler;
 import tw.tib.financisto.service.FinancistoService;
+import tw.tib.financisto.service.NotificationListener;
 
 public class PackageReplaceReceiver extends BroadcastReceiver {
     private static final String TAG = "PackageReplaceReceiver";
@@ -27,6 +28,8 @@ public class PackageReplaceReceiver extends BroadcastReceiver {
         Log.i(TAG, "reschedule transactions and auto backup");
         requestScheduleAll(context);
         requestScheduleAutoBackup(context);
+        // an APK update is the usual moment the notification listener gets unbound
+        NotificationListener.requestRebindIfGranted(context);
     }
 
     protected void requestScheduleAll(Context context) {

--- a/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
+++ b/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
@@ -8,13 +8,18 @@ import static tw.tib.financisto.service.FinancistoService.WALLET_TRANSACTION_TEX
 import static tw.tib.financisto.service.FinancistoService.WALLET_TRANSACTION_TITLE;
 
 import android.app.Notification;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.NotificationListenerService;
 import android.service.notification.StatusBarNotification;
 import android.text.SpannableString;
 import android.util.Log;
+
+import androidx.core.app.NotificationManagerCompat;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -36,6 +41,56 @@ public class NotificationListener extends NotificationListenerService {
 
     private String packageName;
     private NotificationCache notificationCache;
+
+    /** Whether the user has granted notification access to this app. */
+    public static boolean isAccessGranted(Context context) {
+        return NotificationManagerCompat.getEnabledListenerPackages(context)
+                .contains(context.getPackageName());
+    }
+
+    /**
+     * Ask the system to bind the listener again.
+     *
+     * After an APK update the listener can end up unbound while the permission still
+     * shows as granted, so no notifications arrive at all and the only user-visible fix
+     * is toggling notification access off and on in system settings. Disabling and
+     * re-enabling the component does the same thing programmatically; requestRebind()
+     * alone was not enough in my testing.
+     *
+     * The component's enabled state is independent of the grant, which is stored per
+     * component name in Settings.Secure.enabled_notification_listeners, so this does not
+     * drop the permission. It is a no-op when the listener is already bound, and it does
+     * nothing at all when access was never granted.
+     */
+    public static void requestRebindIfGranted(Context context) {
+        if (!isAccessGranted(context)) return;
+        ComponentName cn = new ComponentName(context, NotificationListener.class);
+        try {
+            PackageManager pm = context.getPackageManager();
+            pm.setComponentEnabledSetting(cn,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP);
+            pm.setComponentEnabledSetting(cn,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP);
+        } catch (Exception e) {
+            Log.e(TAG, "toggling listener component failed", e);
+            // never leave the component disabled
+            try {
+                context.getPackageManager().setComponentEnabledSetting(cn,
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                        PackageManager.DONT_KILL_APP);
+            } catch (Exception ignored) {}
+        }
+        // requestRebind() is API 24; on API 23 the component toggle above is all we have
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            try {
+                requestRebind(cn);
+            } catch (Exception e) {
+                Log.e(TAG, "requestRebind failed", e);
+            }
+        }
+    }
 
     @Override
     public void onListenerConnected() {

--- a/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
+++ b/app/src/main/java/tw/tib/financisto/service/NotificationListener.java
@@ -57,6 +57,13 @@ public class NotificationListener extends NotificationListenerService {
      * re-enabling the component does the same thing programmatically; requestRebind()
      * alone was not enough in my testing.
      *
+     * This is not specific to self-signed builds: the same symptom (notification list
+     * empty, access still shown as granted, off/on toggle required to recover) also
+     * reproduces with the Play Store build after a store update, observed on a Xiaomi
+     * phone running HyperOS 3 / Android 16. Vendor builds with aggressive background
+     * management appear more prone to leaving the listener unbound across updates,
+     * which is likely why it does not reproduce on every device.
+     *
      * The component's enabled state is independent of the grant, which is stored per
      * component name in Settings.Secure.enabled_notification_listeners, so this does not
      * drop the permission. It is a no-op when the listener is already bound, and it does


### PR DESCRIPTION
**Please treat this one as a proposal rather than a fix — I only have evidence from my own phone, and I have no idea how common the problem is on other devices. Feel free to reject it if it looks like it is solving a problem you have never seen.**

### What I hit

On my phone the notification listener stops receiving anything after an APK update, while notification access still shows as **granted** in system settings. Nothing arrives — notification templates simply stop working, silently. The only fix I found was toggling notification access off and on by hand in system settings.

It was easy to miss until yesterday, when I happened to install four builds in one day and had to re-grant access every single time.

### What this does

Adds `NotificationListener.requestRebindIfGranted()`, which disables and re-enables the listener component and then calls `requestRebind()`. It is called from three places:

- `Application.onCreate` — the `MY_PACKAGE_REPLACED` broadcast does not always manage to rebind, and opening the app is what a user does anyway once they notice nothing is being recorded
- the `MY_PACKAGE_REPLACED` receiver — the usual moment it breaks
- the notification list screen — the screen a user opens when notifications stopped arriving

### Notes

- The component's enabled state is independent of the grant, which is stored per component name in `Settings.Secure.enabled_notification_listeners`, so this does not drop the permission.
- It is a no-op when the listener is already bound, and does nothing at all when access was never granted, so the extra call sites are cheap.
- `requestRebind()` on its own was **not** enough on my device — that is the only reason the component toggle is there. If it is enough on yours, the toggle can be dropped and this shrinks to a few lines.
- The catch block always re-enables the component, so a failure cannot leave the listener disabled.

Built and verified with `assembleDebug`. Verified on my device that notifications are picked up after an update without touching system settings, but that is a single data point.
