### PR TITLE
Manifest cleanup: remove dead GCM permissions, make FileProvider authority dynamic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,9 +45,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 	<uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
-    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />    
-	<permission android:name="tw.tib.financisto.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-    <uses-permission android:name="tw.tib.financisto.permission.C2D_MESSAGE"/>
 
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -362,7 +362,7 @@
 
 		<provider
 			android:name="androidx.core.content.FileProvider"
-			android:authorities="tw.tib.financisto"
+			android:authorities="${applicationId}"
 			android:grantUriPermissions="true">
 			<meta-data
 				android:name="android.support.FILE_PROVIDER_PATHS"


### PR DESCRIPTION
Two independent manifest fixes, one commit each.

1. Remove unused Google Cloud Messaging permissions

The manifest declares com.google.android.c2dm.permission.RECEIVE and a
custom tw.tib.financisto.permission.C2D_MESSAGE permission. GCM was shut
down by Google in 2019 and no source file references C2DM, GCM or
GoogleCloudMessaging. These are leftovers from the 1.6.8 base.

Removing them reduces the app's declared permission surface and fixes
INSTALL_FAILED_DUPLICATE_PERMISSION when installing a variant with an
applicationIdSuffix alongside the Play Store build.

2. Use ${applicationId} for the FileProvider authority

The FileProvider authority is hardcoded to "tw.tib.financisto". Provider
authorities must be unique per device, so any build variant with a
different applicationId fails to install with
INSTALL_FAILED_CONFLICTING_PROVIDER.

No Java source references the authority string literally, so the
placeholder substitution is transparent. This is the approach recommended
in the Android documentation.

Both changes were verified by building and installing a debug variant
alongside the Play Store release on a device running Android 16.