### PR TITLE
fix: taps ignored on the Reports and Menu tabs after leaving the tab and coming back

### DIFF
--- a/app/src/main/java/tw/tib/financisto/activity/MenuListFragment.java
+++ b/app/src/main/java/tw/tib/financisto/activity/MenuListFragment.java
@@ -130,6 +130,10 @@ public class MenuListFragment extends ListFragment {
         super.onResume();
         PinProtection.unlock(getContext());
         bus.register(this);
+        // See ReportsListFragment.onResume(): after ViewPager2 detaches and re-attaches the
+        // fragment view, AbsListView's mDataChanged stays true until a layout pass, and the first
+        // tap is swallowed.
+        getListView().requestLayout();
     }
 
     ProgressDialog progressDialog;

--- a/app/src/main/java/tw/tib/financisto/activity/ReportsListFragment.java
+++ b/app/src/main/java/tw/tib/financisto/activity/ReportsListFragment.java
@@ -77,6 +77,15 @@ public class ReportsListFragment extends ListFragment {
     public void onResume() {
         super.onResume();
         PinProtection.unlock(getContext());
+        // ViewPager2 detaches the page's fragment view when another tab is selected. On re-attach,
+        // AbsListView.onAttachedToWindow() sets mDataChanged = true ("data may have changed while
+        // we were detached"), and only a layout pass clears it. Coming back, the page bounds are
+        // unchanged and nothing requests a layout, so View.layout() skips onLayout(), the flag
+        // stays set, and the next tap is dropped in onTouchUp(). Dragging the list forces a layout,
+        // which is why scrolling once makes taps work again.
+        // The other tabs are not affected because refreshCurrentTab() re-sets their adapter; this
+        // one is a static list with nothing to refresh.
+        getListView().requestLayout();
     }
 
     @Override


### PR DESCRIPTION
### Symptom

Tapping a row on the **Reports** or **Menu** tab does nothing. Tap again — still nothing. Drag the
list a little so it scrolls, and from then on taps work normally.

Steps to reproduce (from a fresh start, on the Reports or the Menu tab):

1. switch to another tab
2. switch back
3. tap any row → nothing happens

The way most people run into it is different and looks unrelated: open an account or a transaction,
press back, then go to Reports or Menu. But leaving the tab and coming back is the whole trigger —
the activity in between is incidental.

Reproduced both on an API 35 emulator and on the Play Store build on a physical device, with the
same steps.

### Cause

ViewPager2 detaches a page's fragment view when another tab is selected. On re-attach,
`AbsListView.onAttachedToWindow()` sets `mDataChanged = true` — "data may have changed while we were
detached" — and only a layout pass clears it:

```java
if (mAdapter != null && mDataSetObserver == null) {
    mDataSetObserver = new AdapterDataSetObserver();
    mAdapter.registerDataSetObserver(mDataSetObserver);
    // Data may have changed while we were detached. Refresh.
    mDataChanged = true;
    ...
}
```

Coming back to the tab, the page bounds are unchanged and nothing requests a layout, so
`View.layout()` skips `onLayout()`, `layoutChildren()` never runs, and the flag stays set. The next
tap is then dropped in `AbsListView.onTouchUp()`, which only performs the click `if (!mDataChanged
&& mAdapter.isEnabled(motionPosition))`.

Dragging works because `onInterceptTouchEvent()` puts the list into `TOUCH_MODE_DOWN` without
consulting `mDataChanged`, and the resulting scroll lays the children out — which clears the flag.
That is exactly why "scroll once and taps work again".

The other three tabs escape this because `refreshCurrentTab()` re-sets their adapter — which
requests a layout — when the tab becomes current. Reports and Menu are static lists with nothing to
refresh, so they are the only two affected.

### Fix

Request a layout in `onResume()` for both fragments. Two lines.

### Verification

On an API 35 emulator, driving real touch events through `adb shell input` and reading the resulting
activity from `dumpsys`:

| scenario | before | after |
|---|---|---|
| switch tabs, tap a Menu row | dead from the 2nd visit on | 4/4 |
| switch tabs, tap a Reports row | same | 3/3 |
| edit an account → back → switch tab → tap | reproduces | 2/2 on both tabs |

In the failing state I also confirmed the shape of it: repeated taps do nothing, a drag scrolls the
list normally, and a tap right after the drag works — matching the user-visible report.
