### PR TITLE
fix: {{e}} does not match merchant names containing a space

### DIFF
--- a/app/src/androidTest/java/tw/tib/financisto/service/PlaceholderCaptureTest.java
+++ b/app/src/androidTest/java/tw/tib/financisto/service/PlaceholderCaptureTest.java
@@ -2,6 +2,7 @@ package tw.tib.financisto.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -60,5 +61,64 @@ public class PlaceholderCaptureTest {
         assertEquals("Cash(Joint)", captureTransferTo("Cash(Joint)"));
         assertEquals("(存款)", captureTransferTo("(存款)"));
         assertEquals("(旅遊儲蓄金)", captureTransferTo("(旅遊儲蓄金)"));
+    }
+
+    // --- {{e}} (payee / merchant) ---
+
+    /** The usual shape of a card notification: the merchant sits between two fixed labels. */
+    private static final String MERCHANT_TEMPLATE =
+            "信用卡消費通知 消費金額：{{p}}元{{*}}末四碼{{a}}{{*}}商店名稱：{{e}}\n授權碼：";
+
+    private static String captureMerchant(String merchant) {
+        String[] match = SmsTransactionProcessor.findTemplateMatches(MERCHANT_TEMPLATE,
+                "信用卡消費通知 消費金額：4000元\n卡　　號：末四碼1234\n"
+                        + "授權時間：2026/08/31 10:00\n商店名稱：" + merchant + "\n授權碼：000123");
+        assertNotNull("template did not match for merchant: " + merchant, match);
+        return match[Placeholder.PAYEE.ordinal()];
+    }
+
+    @Test
+    public void capturesMerchantWithoutSpace() {
+        assertEquals("甲壽保費", captureMerchant("甲壽保費"));
+        assertEquals("SHOPFAST", captureMerchant("SHOPFAST"));
+        assertEquals("丁購物股份有限公司", captureMerchant("丁購物股份有限公司"));
+    }
+
+    /**
+     * A space is not punctuation but it is not \S either, so with (\S+?) the whole
+     * template fails to match and the notification is dropped without a trace. English
+     * merchant names routinely contain spaces — this is the common case, not an edge one.
+     */
+    @Test
+    public void capturesMerchantWithSpace() {
+        assertEquals("ALPHA THEATRES", captureMerchant("ALPHA THEATRES"));
+        assertEquals("SHOPFAST TW", captureMerchant("SHOPFAST TW"));
+        assertEquals("A1 MART 城中店", captureMerchant("A1 MART 城中店"));
+    }
+
+    /** Non-greedy plus a closing anchor: capture stops at the first anchor, nothing after it. */
+    @Test
+    public void stopsAtTheFirstAnchor() {
+        assertEquals("A B", captureMerchant("A B"));
+        String[] match = SmsTransactionProcessor.findTemplateMatches(
+                "金額NT${{p}}元{{*}}在{{e}} 刷卡。",
+                "丙銀行 【刷卡通知】金額NT$205元 \n"
+                        + "卡號末四碼5678於 2026/08/17 13:57在SHOPFAST TW 刷卡。立即查看消費明細");
+        assertNotNull("template did not match", match);
+        assertEquals("SHOPFAST TW", match[Placeholder.PAYEE.ordinal()]);
+    }
+
+    /**
+     * {{e}} never crosses a line. That is why it uses ([^\r\n]+?) rather than (.+?): the
+     * pattern is compiled with DOTALL, so (.+?) would swallow the line breaks and capture a
+     * multi-line payee whenever the closing anchor only appears further down. If the anchor
+     * is not on the same line the template should simply not match — better no transaction
+     * than a payee spanning two lines.
+     */
+    @Test
+    public void payeeNeverCrossesLines() {
+        assertNull(SmsTransactionProcessor.findTemplateMatches(
+                "消費金額：{{p}}元\n商店名稱：{{e}}授權碼：",
+                "消費金額：4000元\n商店名稱：甲壽保費\n授權碼：000123"));
     }
 }

--- a/app/src/main/java/tw/tib/financisto/service/SmsTransactionProcessor.java
+++ b/app/src/main/java/tw/tib/financisto/service/SmsTransactionProcessor.java
@@ -53,7 +53,19 @@ public class SmsTransactionProcessor {
                 String parsedPrice = match[PRICE.ordinal()];
                 String text = match[TEXT.ordinal()];
                 String greedy_text = match[GREEDY_TEXT.ordinal()];
-                String payeeText =  match[PAYEE.ordinal()];
+                // {{e}} now accepts merchant names containing spaces (see Placeholder.PAYEE),
+                // and the price of that is picking up the surrounding whitespace as well
+                // (a trailing space after the merchant name is common). A payee is created
+                // when it is not found, so without trimming we end up with two payees that
+                // differ only by a space — and the payee is what carries lastCategoryId, so
+                // splitting it in two loses the remembered category.
+                String payeeText = match[PAYEE.ordinal()];
+                if (payeeText != null) {
+                    payeeText = payeeText.trim();
+                    if (payeeText.isEmpty()) {
+                        payeeText = null;
+                    }
+                }
                 String projectText = match[PROJECT.ordinal()];
                 String currencyText = match[CURRENCY.ordinal()];
                 String timestampMillisText = match[TIMESTAMP_MILLIS.ordinal()];
@@ -359,7 +371,19 @@ public class SmsTransactionProcessor {
         BALANCE("<:B:>", "\\s{0,3}([\\d\\.,\\-\\+\\']+(?:[\\d \\xA0\\.,]+?)*)\\s{0,3}", "{{b}}"),
         ACCOUNT_NAME("<:C:>", "(\\S+?)", "{{c}}"),
         DATE("<:D:>", "\\s{0,3}(\\d[\\d\\. /:-]{12,14}\\d)\\s*?", "{{d}}"),
-        PAYEE("<:E:>", "(\\S+?)", "{{e}}"),
+        // (\S+?) fails on merchant names containing a space ("ALPHA THEATRES",
+        // "SHOPFAST TW"): the template then does not match at all, so the notification is
+        // silently dropped and no transaction is created. Spaces inside a merchant name
+        // are common, and the failure is invisible — nothing is logged as an error, the
+        // ledger is simply missing an entry. Use ([^\r\n]+?): a merchant name never spans
+        // lines, and excluding the line breaks stops a runaway capture when the closing
+        // anchor only appears on a later line (the pattern is compiled with DOTALL).
+        // [^\r\n] is a superset of \S, and both are non-greedy, so they expand identically
+        // until a space is needed — every template that matched before matches the same
+        // way, and only previously-failing ones start to match.
+        // Covered by PlaceholderCaptureTest in androidTest — it has to run on a device,
+        // because Android's regex is ICU-backed and a desktop JVM answers differently.
+        PAYEE("<:E:>", "([^\\r\\n]+?)", "{{e}}"),
         CURRENCY("<:F:>", "([A-Z]{3})", "{{f}}"),
         TIMESTAMP_MILLIS("<:G:>", "(\\d{1,13})", "{{g}}"),
         PRICE("<:P:>", BALANCE.regexp, "{{p}}"),
@@ -368,8 +392,12 @@ public class SmsTransactionProcessor {
         GREEDY_TEXT("<:U:>", "(.*)", "{{u}}"),
         // (\w+?) fails on account titles containing punctuation such as "-" or "()":
         // those are not word characters, so the template does not match at all and no
-        // transaction is created. Use (\S+?), consistent with ACCOUNT_NAME / PAYEE /
-        // PROJECT above; \S is a superset of \w, so existing templates keep working.
+        // transaction is created. Use (\S+?), consistent with ACCOUNT_NAME / PROJECT
+        // above; \S is a superset of \w, so existing templates keep working.
+        // Left as (\S+?) rather than widened like PAYEE: an account title containing a
+        // space would break the same way, but there is no reported case, and these two
+        // are matched against existing entities rather than created on the fly. Widen
+        // them the same way if one turns up.
         // Covered by PlaceholderCaptureTest in androidTest — it has to run on a device,
         // because Android's regex is ICU-backed and a desktop JVM answers differently.
         TRANSFER_TO_ACCOUNT_NAME("<:X:>", "(\\S+?)", "{{x}}");


### PR DESCRIPTION
## Motivation

`{{e}}` captures with `(\S+?)`, which stops at the first whitespace. A notification whose merchant name contains a space — `ALPHA THEATRES`, `SHOPFAST TW`, `A1 MART 城中店` — therefore fails to match the **whole** template, so no transaction is created.

The failure is invisible: nothing is logged as an error, the template is not reported as broken, the ledger is simply missing an entry. Spaces in merchant names are common rather than exotic, so this is a routine way to silently lose transactions.

Same family as #133 (`{{x}}` and account titles containing punctuation), one placeholder further along.

## Implementation

`PAYEE` becomes `([^\r\n]+?)`.

- `[^\r\n]` is a **superset** of `\S`, and both are non-greedy, so they expand identically until a space has to be crossed. Every template that matched before matches the same way and captures the same text; only previously-failing ones start to match.
- Excluding the line breaks is the point, and is why this is not `(.+?)`: the pattern is compiled with `DOTALL`, so `(.+?)` keeps going across lines whenever the closing anchor only appears further down, producing a payee spanning two lines instead of simply not matching. A merchant name never spans lines.

The widened capture also picks up the whitespace around the name (a trailing space after the merchant is common in these notifications), so `payeeText` is trimmed. A payee is created when it is not found, so without trimming you end up with two payees differing only by a space — and the payee is what carries `lastCategoryId`, so splitting it loses the remembered category.

`{{c}}` and `{{x}}` are deliberately left as `(\S+?)`: an account title containing a space would break the same way, but there is no reported case, and those two are matched against existing entities rather than created on the fly. Easy to widen the same way if one turns up.

## Testing

`PlaceholderCaptureTest` (androidTest — Android's regex is ICU-backed, a desktop JVM answers differently) gains four cases: a merchant with a space, one without, stopping at the first anchor, and never crossing a line.

On an API 35 emulator, each variant is red on exactly what it gets wrong:

| `PAYEE` pattern | result |
|---|---|
| `([^\r\n]+?)` (this PR) | 8/8 pass |
| `(\S+?)` (current) | 2 fail — `capturesMerchantWithSpace`, `stopsAtTheFirstAnchor`: *template did not match for merchant: ALPHA THEATRES* |
| `(.+?)` (naive widening) | 1 fail — `payeeNeverCrossesLines`: *expected null, but was:<...>* |

The no-space cases pass in all three, which is the point: this widens what matches, it does not change what already matched.

## Known limitations

- Templates that were relying on `{{e}}` stopping at a space to end a capture early would now capture further — but only up to the next anchor, and `{{e}}` needs a closing anchor to be usable at all, so a template written that way would already have been fragile.
- Nothing else changes: no schema, no other placeholder, no template migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
