### PR TITLE
fix: last list item hidden behind the navigation bar on the SMS template and notification lists

### DIFF
--- a/app/src/main/java/tw/tib/financisto/activity/NotificationListActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/NotificationListActivity.java
@@ -48,6 +48,24 @@ public class NotificationListActivity extends AppCompatActivity {
             return WindowInsetsCompat.CONSUMED;
         });
 
+        // Bottom insets: under edge-to-edge the last list item ends up behind the
+        // navigation bar and cannot be scrolled clear of it. Do what the settings screen
+        // (androidx preference) does: pad by the navigation bar height and turn off
+        // clipToPadding, so content still scrolls under the bar but the last item comes
+        // fully clear at the end of the list.
+        //
+        // The listener is attached to the root rather than the list: insets are dispatched
+        // to the root first, and the toolbar listener above returns CONSUMED, so a listener
+        // on the list itself may receive already-consumed insets. This one does not consume
+        // them, leaving the toolbar's top handling untouched.
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.notification_list), (v, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            ListView lv = findViewById(android.R.id.list);
+            lv.setPadding(lv.getPaddingLeft(), lv.getPaddingTop(), lv.getPaddingRight(), insets.bottom);
+            lv.setClipToPadding(false);
+            return windowInsets;
+        });
+
         // opening this screen is what a user does when notifications stopped arriving,
         // so let it heal a listener the system silently unbound
         NotificationListener.requestRebindIfGranted(this);

--- a/app/src/main/java/tw/tib/financisto/activity/SmsDragListActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/SmsDragListActivity.java
@@ -62,6 +62,18 @@ public class SmsDragListActivity extends AppCompatActivity {
             return WindowInsetsCompat.CONSUMED;
         });
 
+        // Bottom insets, same as NotificationListActivity: pad the list by the navigation
+        // bar height with clipToPadding off so the last item can be scrolled clear of it.
+        // Attached to the root and not consuming, because the toolbar listener above
+        // returns CONSUMED and still needs to handle the top inset.
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.sms_template_list_base), (v, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            View lv = findViewById(R.id.drag_list_view);
+            lv.setPadding(lv.getPaddingLeft(), lv.getPaddingTop(), lv.getPaddingRight(), insets.bottom);
+            if (lv instanceof ViewGroup) ((ViewGroup) lv).setClipToPadding(false);
+            return windowInsets;
+        });
+
         db = new DatabaseAdapter(this);
         db.open();
         


### PR DESCRIPTION
## Motivation

Under edge-to-edge, `SmsDragListActivity` and `NotificationListActivity` only handle the **top** inset. The bottom one is never applied, so the last item of the list sits behind the navigation bar and cannot be scrolled clear of it — the list simply ends underneath the bar.

Both screens already have a toolbar inset listener; this is the missing half of it.

## Implementation

Do what the settings screen (androidx `preference`) already does: pad the list by the navigation bar height and turn `clipToPadding` off, so content still scrolls under the bar while the last item comes fully clear at the end of the list.

The listener is attached to the **root** rather than to the list, because insets are dispatched to the root first and the existing toolbar listener returns `CONSUMED` — a listener on the list itself can therefore receive already-consumed insets. This one returns the insets unchanged, so the toolbar's top handling is untouched.

8 lines per screen, no layout XML changes.

## Testing

API 35 emulator, 1080x2400, navigation bar top edge at y=2337. 40 templates in the list, scrolled all the way to the bottom, bounds read from `uiautomator dump`:

| | last item `bounds` bottom | |
|---|---|---|
| before | 2386 | **49px behind the navigation bar** |
| after | 2323 | 14px clear of it |

The toolbar and status bar spacing is unchanged in both runs.

The notification list gets the same treatment, but I could not fill it far enough to measure: on API 35 notifications posted with `cmd notification post` never reach a listener, so only the two system notifications ever appear and the list does not overflow. It is the same code path as the one measured above, but if you would rather I split it out and only ship the template list, say so and I will.

## Known limitations

- Only these two screens. Other list screens may have the same gap; I did not audit them in this PR.
- Landscape/gesture-navigation variants were not measured separately — the fix reads the actual `systemBars()` inset, so it follows whatever the bar height is, but I only have the three-button emulator measurement above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
