### PR TITLE
fix: filter icon lit on arrival in the account blotter

### DIFF
--- a/app/src/main/java/tw/tib/financisto/activity/BlotterFragment.java
+++ b/app/src/main/java/tw/tib/financisto/activity/BlotterFragment.java
@@ -1156,7 +1156,34 @@ public class BlotterFragment extends AbstractListFragment<Cursor> implements Blo
     }
 
     protected void updateFilterImage() {
-        FilterState.updateFilterColor(getContext(), blotterFilter, bFilter);
+        FilterState.updateFilterColor(getContext(), blotterFilter, bFilter,
+                isNavigationOnlyFilter(isAccountBlotter, blotterFilter));
+    }
+
+    /**
+     * Whether everything in this filter came from navigation rather than from the user
+     * picking it in the filter screen.
+     *
+     * Opening an account from the account list lands on a blotter that shows only that
+     * account: the account criterion is part of "show me this account", not a filter the
+     * user expressed. It lives in the same WhereFilter as real filters though, so
+     * isEmpty() is false and the filter icon lights up the moment the screen opens —
+     * claiming "what you see is not everything" before the user has done anything, which
+     * also costs the icon its meaning when a filter really is applied. Adding any further
+     * criterion (category, date, ...) makes it the user's intent again. Picking an account
+     * from the transactions screen through the filter UI is intentional and unaffected.
+     *
+     * The test is on the filter's *contents*, not on "has the filter screen been opened":
+     * in the account blotter the filter screen's clear button restores "just this account"
+     * (see BlotterFilterActivity.bNoFilter), so a has-been-opened flag would leave the icon
+     * lit after the user cleared everything. The account criterion also cannot be removed
+     * there (its minus button is hidden), which is what makes "exactly one criterion, and
+     * it is the account" a stable shape.
+     */
+    static boolean isNavigationOnlyFilter(boolean isAccountBlotter, WhereFilter filter) {
+        return isAccountBlotter
+                && filter.getAccountId() > 0
+                && filter.criteriaCount() == 1;
     }
 
     @Override

--- a/app/src/main/java/tw/tib/financisto/activity/FilterState.java
+++ b/app/src/main/java/tw/tib/financisto/activity/FilterState.java
@@ -9,7 +9,20 @@ import tw.tib.financisto.filter.WhereFilter;
 class FilterState {
 
     static void updateFilterColor(Context context, WhereFilter filter, ImageButton button) {
-        int color = filter.isEmpty() ? context.getResources().getColor(R.color.bottom_bar_tint) : context.getResources().getColor(R.color.holo_blue_bright);
+        updateFilterColor(context, filter, button, false);
+    }
+
+    /**
+     * @param treatAsUnfiltered the filter is not empty, but everything in it came from
+     *                          navigation rather than from the user. The account blotter is
+     *                          the case: it always carries that account's criterion, yet the
+     *                          user has not picked anything, so the icon should not be lit
+     *                          (a lit icon means "what you see is not everything").
+     */
+    static void updateFilterColor(Context context, WhereFilter filter, ImageButton button,
+                                  boolean treatAsUnfiltered) {
+        boolean unfiltered = treatAsUnfiltered || filter.isEmpty();
+        int color = unfiltered ? context.getResources().getColor(R.color.bottom_bar_tint) : context.getResources().getColor(R.color.holo_blue_bright);
         if (button != null) {
             button.setColorFilter(color);
         }

--- a/app/src/main/java/tw/tib/financisto/filter/WhereFilter.java
+++ b/app/src/main/java/tw/tib/financisto/filter/WhereFilter.java
@@ -364,6 +364,14 @@ public class WhereFilter {
 		return title;
 	}
 
+	/**
+	 * Number of criteria in this filter. For telling "is this filter down to a single
+	 * condition" apart from "is it empty" — see BlotterFragment.isNavigationOnlyFilter.
+	 */
+	public synchronized int criteriaCount() {
+		return criteria.size();
+	}
+
 	public synchronized boolean isEmpty() {
 		return criteria.isEmpty();
 	}

--- a/app/src/test/java/tw/tib/financisto/activity/NavigationOnlyFilterTest.java
+++ b/app/src/test/java/tw/tib/financisto/activity/NavigationOnlyFilterTest.java
@@ -1,0 +1,53 @@
+package tw.tib.financisto.activity;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tw.tib.financisto.blotter.BlotterFilter;
+import tw.tib.financisto.filter.WhereFilter;
+
+/**
+ * Telling a filter the user asked for apart from one navigation brought along.
+ *
+ * Opening an account from the account list lands on a blotter that shows only that
+ * account, so the account criterion is part of the navigation rather than something the
+ * user picked. Picking an account from the transactions screen through the filter UI is
+ * the opposite: that is the user's intent.
+ */
+public class NavigationOnlyFilterTest {
+
+    private static WhereFilter accountOnly() {
+        return WhereFilter.empty().eq(BlotterFilter.FROM_ACCOUNT_ID, "5");
+    }
+
+    @Test
+    public void accountBlotterWithOnlyTheAccountIsNavigationOnly() {
+        assertTrue(BlotterFragment.isNavigationOnlyFilter(true, accountOnly()));
+    }
+
+    @Test
+    public void accountBlotterWithAnExtraCriterionIsUserIntent() {
+        WhereFilter f = accountOnly().eq(BlotterFilter.CATEGORY_ID, "7");
+        assertFalse("the user added a category on top of the account blotter",
+                BlotterFragment.isNavigationOnlyFilter(true, f));
+    }
+
+    @Test
+    public void accountBlotterWithAStatusCriterionIsUserIntent() {
+        WhereFilter f = accountOnly().eq(BlotterFilter.STATUS, "PN");
+        assertFalse(BlotterFragment.isNavigationOnlyFilter(true, f));
+    }
+
+    /** Same filter contents, but reached through the filter screen: that is user intent. */
+    @Test
+    public void accountPickedInTheFilterScreenIsUserIntent() {
+        assertFalse(BlotterFragment.isNavigationOnlyFilter(false, accountOnly()));
+    }
+
+    @Test
+    public void emptyFilterIsNotNavigationOnly() {
+        assertFalse(BlotterFragment.isNavigationOnlyFilter(true, WhereFilter.empty()));
+    }
+}


### PR DESCRIPTION
## Motivation

Opening an account from the account list lands on a blotter that shows only that account. The account criterion is part of *"show me this account"*, not a filter the user expressed — but it lives in the same `WhereFilter` as real filters, so `isEmpty()` is false and **the filter icon is already lit the moment the screen opens**.

Two things go wrong with that:

- It claims "what you see is not everything" before the user has done anything.
- It costs the icon its meaning: if it is always blue here, it no longer signals the case where a filter really *is* applied.

## Implementation

`FilterState.updateFilterColor` gets a `treatAsUnfiltered` overload; the account blotter passes a predicate:

```java
static boolean isNavigationOnlyFilter(boolean isAccountBlotter, WhereFilter filter) {
    return isAccountBlotter && filter.getAccountId() > 0 && filter.criteriaCount() == 1;
}
```

Adding any further criterion (category, date, …) makes it the user's intent again and the icon lights up as before. Picking an account from the transactions screen through the filter UI is intentional and unaffected. `BudgetListFragment` / `ReportActivity` go through the existing overload, unchanged.

**Why test the filter's contents rather than "has the filter screen been opened":** in the account blotter the clear button restores *"just this account"* (`BlotterFilterActivity.bNoFilter`), so a has-been-opened flag would leave the icon lit right after the user cleared everything. The account criterion also cannot be removed there — its minus button is hidden by `disableAccountResetButtonIfNeeded()` — which is what makes "exactly one criterion, and it is the account" a stable shape to test for.

`WhereFilter.criteriaCount()` is the one small addition needed for that.

## Testing

`NavigationOnlyFilterTest` — plain JVM unit tests, no device needed — pins the predicate with five cases, all passing:

```
accountBlotterWithOnlyTheAccountIsNavigationOnly
accountBlotterWithAnExtraCriterionIsUserIntent
accountBlotterWithAStatusCriterionIsUserIntent
accountPickedInTheFilterScreenIsUserIntent
emptyFilterIsNotNavigationOnly
```

I could not attach a before/after screenshot: `adb shell screencap` returns an all-black image for this screen on the emulator (software GPU), so the icon colour is not readable there. The wiring itself is the single call in `updateFilterImage()`.

## Known limitations

- Only the account blotter is treated this way. If other screens arrive with a navigation-supplied filter, they would need the same predicate — I did not audit for that here.
- The icon's meaning is the only thing that changes; the filter itself, the query, and everything reachable from the filter screen are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
