### PR TITLE
Allow splitting the difference in balance-adjust mode

### DIFF
--- a/app/src/main/java/tw/tib/financisto/activity/TransactionActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TransactionActivity.java
@@ -461,6 +461,18 @@ public class TransactionActivity extends AbstractTransactionActivity {
 
             u.setAccountTitleBalance(a, accountText, accountBalanceText, accountLimitText);
 
+            // Balance-adjust mode: the difference is (new balance - current balance) of the
+            // account that is selected *now*. currentBalance was only read from the intent
+            // once, so after switching accounts the difference was still computed against
+            // the balance of the account the form was opened with.
+            if (isUpdateBalanceMode && selectedAccount != null && a.id != selectedAccount.id) {
+                currentBalance = a.totalAmount;
+                if (differenceText != null) {
+                    u.setAmountText(differenceText, rateView.getCurrencyFrom(),
+                            rateView.getFromAmount() - currentBalance, true);
+                }
+            }
+
             selectedAccount = a;
 
             if (selectLast && !isShowPayee && isRememberLastCategory) {

--- a/app/src/main/java/tw/tib/financisto/activity/TransactionActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TransactionActivity.java
@@ -168,7 +168,9 @@ public class TransactionActivity extends AbstractTransactionActivity {
 
     private void unsplitAdjustAmount() {
         long splitAmount = calculateSplitAmount();
-        rateView.setFromAmount(splitAmount);
+        // In balance-adjust mode the amount field holds the *new balance*, so the sum of the
+        // splits maps back to currentBalance + sum rather than to the sum itself.
+        rateView.setFromAmount(isUpdateBalanceMode ? currentBalance + splitAmount : splitAmount);
         updateUnsplitAmount();
     }
 
@@ -208,7 +210,10 @@ public class TransactionActivity extends AbstractTransactionActivity {
 
     @Override
     protected void fetchCategories() {
-        categorySelector.fetchCategories(!isUpdateBalanceMode);
+        // Balance-adjust mode lists the "Split" pseudo-category as well: the two queries only
+        // differ by the "_id >= 0" filter, and SPLIT_CATEGORY_ID (-1) is the only negative id.
+        // Splits hang off the difference, see calculateUnsplitAmount().
+        categorySelector.fetchCategories(true);
     }
 
     @Override
@@ -242,10 +247,14 @@ public class TransactionActivity extends AbstractTransactionActivity {
         // difference
         if (isUpdateBalanceMode) {
             differenceText = x.addInfoNode(layout, -1, R.string.difference, "0");
+            // Splits go right under the "Difference" row: the amount field is the counted
+            // result, the difference is what this transaction records, and that is what gets split.
+            createSplitsLayout(layout);
             rateView.setFromAmount(currentBalance);
             rateView.setAmountFromChangeListener((oldAmount, newAmount) -> {
                 long balanceDifference = newAmount - currentBalance;
                 u.setAmountText(differenceText, rateView.getCurrencyFrom(), balanceDifference, true);
+                updateUnsplitAmount();
             });
             if (currentBalance > 0) {
                 rateView.setIncome();
@@ -301,7 +310,14 @@ public class TransactionActivity extends AbstractTransactionActivity {
 
     private long calculateUnsplitAmount() {
         long splitAmount = calculateSplitAmount();
-        return rateView.getFromAmount() - splitAmount;
+        // Balance-adjust mode: the amount field is the new balance; the transaction itself
+        // records the difference (new balance - current balance) and the splits divide that.
+        // Same base as updateTransactionFromUI(), which subtracts currentBalance on save.
+        long amount = rateView.getFromAmount();
+        if (isUpdateBalanceMode) {
+            amount -= currentBalance;
+        }
+        return amount - splitAmount;
     }
 
     private long calculateSplitAmount() {
@@ -474,6 +490,14 @@ public class TransactionActivity extends AbstractTransactionActivity {
             }
 
             selectedAccount = a;
+
+            // Recompute the unsplit amount only now: calculateSplitAmount() decides each child's
+            // direction via getSelectedAccountId(), so the remapped children would be skipped if
+            // this ran before selectedAccount was updated. In balance-adjust mode currentBalance
+            // has changed as well, which moves the base the splits are subtracted from.
+            if (!viewToSplitMap.isEmpty()) {
+                updateUnsplitAmount();
+            }
 
             if (selectLast && !isShowPayee && isRememberLastCategory) {
                 categorySelector.selectCategory(a.lastCategoryId);


### PR DESCRIPTION
## Motivation

"Update balance" (long-press an account → update balance) always produces a single-category transaction. The category picker is built with the "Split" pseudo-category filtered out and the splits container is never created, so someone who counts the cash in their wallet and wants to attribute the difference to several categories has to save first and then re-open the transaction to split it.

Second, smaller thing found while working on this: the "Difference" row in that form is computed against the balance of the account the form was opened with. Switching to another account in the form keeps subtracting the original account's balance, so the difference shown — and the amount saved — is off by the gap between the two balances.

## Implementation

Two commits, independent enough to be taken separately:

1. **fix: recompute the balance difference when the account is switched** — `selectAccount()` refreshes `currentBalance` and the difference row when the selected account actually changes. The first selection (opening the form) is untouched; the intent already carries that account's balance.

2. **feat: allow splitting the difference in balance-adjust mode** — splits hang off the *difference* (new balance − current balance), which is the amount the transaction records anyway (`updateTransactionFromUI()` already subtracts `currentBalance` on save):
   - `fetchCategories()` no longer hides "Split" in balance-adjust mode. The two queries only differ by the `_id >= 0` filter and `SPLIT_CATEGORY_ID` (-1) is the only negative id, so this is the single thing that kept "Split" out of the picker.
   - the splits container is created under the "Difference" row.
   - `calculateUnsplitAmount()` subtracts `currentBalance` first in balance-adjust mode, so unsplit = difference − Σ splits. The amount-change listener also refreshes the unsplit row.
   - the "Amount" quick action maps Σ splits back to a new balance (`currentBalance + Σ`) instead of writing the sum into the new-balance field.
   - the unsplit amount is recomputed after `selectedAccount` (and, in balance-adjust mode, `currentBalance`) has been updated. `calculateSplitAmount()` decides each child's direction via `getSelectedAccountId()`, so recomputing before that point skips the re-mapped children.

   Everything else is reused unchanged: the "+" button pre-filling the remainder, the evenly/last quick actions, save being blocked while unsplit ≠ 0, state restore on rotation. No new UI, no new strings — `unsplit_amount` and `difference` already exist in every locale.

## Testing

Manual, on the `google_apis` API 35 x86_64 emulator with a restored ledger (~35 accounts), driven with `am start` + `uiautomator dump` so the numbers below are read from the view tree, not eyeballed. Account A has balance 1,146.00, account B 6,810.00 (TWD).

**Commit 1** — open "update balance" on A, leave the amount at 1,146, switch the account to B:
- master: "Difference" keeps showing 0 (`currentBalance` is never updated after `onCreate`).
- with the fix: "Difference" = **−5,664** (1,146 − 6,810).

**Commit 2** — open "update balance" on A, type 752 (difference −394):
- pick "Split" → "Unsplit amount" **−394** (= difference); on master "Split" is not in the picker at all.
- "+" → split editor pre-filled with 394 (expense direction); change to 80, save → unsplit **−314**, one child −80.
- "+" again → pre-filled with 314, save → unsplit **0**, children −80 / −314.
- edit the new balance to 700 → difference −446, unsplit −52 (listener path); "Amount" quick action → new balance back to **752**, unsplit 0.
- save → DB: parent `from_amount=-39400, category_id=-1`, children `-8000` and `-31400` with `parent_id` = parent; account balance 75,200 (= the 752 that was typed).
- switching accounts with splits present recomputes unsplit against the new account's balance (checked on the same build); in a plain expense transaction with splits the unsplit amount stays unchanged after an account switch.

`./gradlew testDebugUnitTest`: the 4 failures in `GoogleWalletNotificationParserTest` are unrelated — this PR only touches `TransactionActivity.java`.

## Known limitations

- The transfer-type split (the transfer icon next to "+") in balance-adjust mode was not part of the emulator run above. It was exercised afterwards on a phone (Android 16) running a build with these two commits applied: one transfer child and one category child under a single balance adjustment, saved correctly.
- Rotation/state restore with splits in balance-adjust mode is the existing `onSaveInstanceState` path, not separately tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

