### PR TITLE
feat: add transaction tagging, autocomplete, intent support.....

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -271,6 +271,11 @@
 			android:theme="@style/AppDialog" android:configChanges="screenSize|smallestScreenSize|orientation|screenLayout|keyboardHidden"/>
 		
 		<activity android:name=".activity.ProjectListActivity" android:label="@string/projects"/>
+
+		<activity android:name=".activity.TagActivity" android:label="@string/tag"
+			android:theme="@style/AppDialog" android:configChanges="screenSize|smallestScreenSize|orientation|screenLayout|keyboardHidden"/>
+
+		<activity android:name=".activity.TagListActivity" android:label="@string/tags"/>
 		
 		<activity android:name=".activity.PayeeActivity" android:label="@string/payee"
 			android:theme="@style/AppDialog" android:configChanges="screenSize|smallestScreenSize|orientation|screenLayout|keyboardHidden"/>

--- a/app/src/main/assets/database/alter/20260910_1200_add_tags_to_transactions.sql
+++ b/app/src/main/assets/database/alter/20260910_1200_add_tags_to_transactions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions ADD COLUMN tags TEXT;

--- a/app/src/main/assets/database/alter/20260910_1300_create_tag_table.sql
+++ b/app/src/main/assets/database/alter/20260910_1300_create_tag_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS tag (
+    _id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    updated_on INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_tag_title ON tag(title);

--- a/app/src/main/assets/database/view/010[v_all_transactions].sql
+++ b/app/src/main/assets/database/view/010[v_all_transactions].sql
@@ -39,7 +39,8 @@ SELECT
 	t.attached_picture as attached_picture,
 	frb.balance as from_account_balance,
 	trb.balance as to_account_balance,
-	t.to_account_id as is_transfer
+	t.to_account_id as is_transfer,
+	t.tags as tags
 FROM
 	transactions as t
 	INNER JOIN account as a1 ON a1._id=t.from_account_id

--- a/app/src/main/assets/database/view/015[v_blotter_for_account_with_splits].sql
+++ b/app/src/main/assets/database/view/015[v_blotter_for_account_with_splits].sql
@@ -39,7 +39,8 @@ SELECT
 	t.attached_picture as attached_picture,
 	rb.balance as from_account_balance,
 	0 as to_account_balance,
-	t.to_account_id as is_transfer
+	t.to_account_id as is_transfer,
+	t.tags as tags
 FROM
 	transactions as t
 	INNER JOIN account as a ON a._id=t.from_account_id
@@ -93,7 +94,8 @@ SELECT
 	t.attached_picture as attached_picture,
 	rb.balance as from_account_balance,
 	0 as to_account_balance,
-	-1 as is_transfer
+	-1 as is_transfer,
+	t.tags as tags
 FROM
 	transactions as t
 	INNER JOIN account as a ON a._id=t.to_account_id

--- a/app/src/main/java/tw/tib/financisto/activity/AbstractSplitActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/AbstractSplitActivity.java
@@ -261,7 +261,7 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
                 for (String tag : intentTags) {
                     db.findOrInsertEntityByTitle(Tag.class, tag);
                 }
-                split.tags = String.join(", ", intentTags);
+                split.tags = String.join("\n", intentTags);
             }
         }
         if (tagSelector != null && split.tags != null) {

--- a/app/src/main/java/tw/tib/financisto/activity/AbstractSplitActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/AbstractSplitActivity.java
@@ -10,13 +10,16 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
+import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
 import tw.tib.financisto.R;
 import tw.tib.financisto.datetime.DateUtils;
 import tw.tib.financisto.model.Account;
 import tw.tib.financisto.model.Currency;
+import tw.tib.financisto.model.Tag;
 import tw.tib.financisto.model.Transaction;
 import tw.tib.financisto.model.TransactionStatus;
+import tw.tib.financisto.service.IntentTransactionProcessor;
 import tw.tib.financisto.utils.CurrencyCache;
 import tw.tib.financisto.utils.EnumUtils;
 import tw.tib.financisto.utils.MyPreferences;
@@ -31,6 +34,7 @@ import androidx.core.view.WindowInsetsCompat;
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Created by IntelliJ IDEA.
@@ -49,6 +53,7 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
     protected TextView editDisabled;
 
     protected EditText noteText;
+    protected TagSelector<AbstractSplitActivity> tagSelector;
     protected TextView unsplitAmountText;
 
     protected Account fromAccount;
@@ -132,8 +137,9 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
         int locationOrder = MyPreferences.getLocationOrder();
         int noteOrder = MyPreferences.getNoteOrder();
         int projectOrder = MyPreferences.getProjectOrder();
+        int tagsOrder = MyPreferences.getTagsOrder();
 
-        for (int i = 0; i < 6; i++) {
+        for (int i = 0; i < 7; i++) {
             if (i == noteOrder) {
                 noteText = new EditText(this);
                 noteText.setId(R.id.note);
@@ -144,6 +150,11 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
             }
             if (i == locationOrder) {
                 locationSelector.createNode(layout);
+            }
+            if (i == tagsOrder) {
+                if (MyPreferences.isShowTags()) {
+                    createTagsNode(layout);
+                }
             }
         }
 
@@ -157,9 +168,15 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
         });
     }
 
+    protected void createTagsNode(LinearLayout layout) {
+        tagSelector = new TagSelector<>(this, db, x);
+        tagSelector.createNode(layout);
+    }
+
     protected void updateCommonUIforPreventEditing() {
         boolean enabled = !isPreventEditing();
         if (noteText != null) noteText.setEnabled(enabled);
+        if (tagSelector != null) tagSelector.setEnabled(enabled);
         if (projectSelector != null) projectSelector.setEnabled(enabled);
         if (locationSelector != null) locationSelector.setEnabled(enabled);
 
@@ -183,6 +200,7 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
     protected void onClick(View v, int id) {
         locationSelector.onClick(id);
         projectSelector.onClick(id);
+        if (tagSelector != null) tagSelector.onClick(id);
     }
 
     @Override
@@ -224,6 +242,9 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
 
     protected boolean updateFromUI() {
         split.note = text(noteText);
+        if (tagSelector != null) {
+            split.tags = tagSelector.getSelectedTags();
+        }
         split.locationId = locationSelector.getSelectedEntityId();
         split.projectId = projectSelector.getSelectedEntityId();
         return true;
@@ -233,6 +254,20 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
         locationSelector.selectEntity(split.locationId);
         projectSelector.selectEntity(split.projectId);
         setNote(split.note);
+        Intent intent = getIntent();
+        if (intent != null) {
+            List<String> intentTags = IntentTransactionProcessor.extractTagsFromIntent(intent);
+            if (!intentTags.isEmpty()) {
+                for (String tag : intentTags) {
+                    db.findOrInsertEntityByTitle(Tag.class, tag);
+                }
+                split.tags = String.join(", ", intentTags);
+            }
+        }
+        if (tagSelector != null && split.tags != null) {
+            tagSelector.setSelectedTags(split.tags);
+            tagSelector.fetchEntities();
+        }
     }
 
     private void setNote(String note) {
@@ -263,6 +298,7 @@ public abstract class AbstractSplitActivity extends AbstractActivity {
     protected void onDestroy() {
         if (locationSelector != null) locationSelector.onDestroy();
         if (projectSelector != null) projectSelector.onDestroy();
+        if (tagSelector != null) tagSelector.onDestroy();
         super.onDestroy();
     }
 }

--- a/app/src/main/java/tw/tib/financisto/activity/AbstractTransactionActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/AbstractTransactionActivity.java
@@ -396,7 +396,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 				for (String tag : intentTags) {
 					db.findOrInsertEntityByTitle(Tag.class, tag);
 				}
-				String intentTagsStr = String.join(", ", intentTags);
+				String intentTagsStr = String.join("\n", intentTags);
 				transaction.tags = intentTagsStr;
 				if (isShowTags && tagSelector != null) {
 					tagSelector.setSelectedTags(intentTagsStr);

--- a/app/src/main/java/tw/tib/financisto/activity/AbstractTransactionActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/AbstractTransactionActivity.java
@@ -40,11 +40,13 @@ import tw.tib.financisto.model.Attribute;
 import tw.tib.financisto.model.Category;
 import tw.tib.financisto.model.Payee;
 import tw.tib.financisto.model.SystemAttribute;
+import tw.tib.financisto.model.Tag;
 import tw.tib.financisto.model.Transaction;
 import tw.tib.financisto.model.TransactionAttribute;
 import tw.tib.financisto.model.TransactionStatus;
 import tw.tib.financisto.recur.NotificationOptions;
 import tw.tib.financisto.recur.Recurrence;
+import tw.tib.financisto.service.IntentTransactionProcessor;
 import tw.tib.financisto.utils.EnumUtils;
 import tw.tib.financisto.utils.MyPreferences;
 import tw.tib.financisto.utils.PicturesUtil;
@@ -83,6 +85,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 	public static final String TEMPLATE_EXTRA = "isTemplate";
 	public static final String DATETIME_EXTRA = "dateTimeExtra";
 	public static final String NEW_FROM_TEMPLATE_EXTRA = "newFromTemplateExtra";
+	public static final String TAGS_EXTRA = "tags";
 
 	private static final int RECURRENCE_REQUEST = 4003;
 	private static final int NOTIFICATION_REQUEST = 4004;
@@ -103,6 +106,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 	protected Button timeText;
 
 	protected EditText noteText;
+	protected TagSelector<AbstractTransactionActivity> tagSelector;
 	protected TextView recurText;
 	protected TextView notificationText;
 
@@ -136,6 +140,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 	protected boolean isShowLocation;
 	protected boolean isShowProject;
 	protected boolean isShowNote;
+	protected boolean isShowTags;
 	protected boolean isShowTakePicture;
 	protected boolean isShowIsCCardPayment;
 	protected boolean isOpenCalculatorForTemplates;
@@ -203,6 +208,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		isShowLocation = MyPreferences.isShowLocation();
 		isShowProject = MyPreferences.isShowProject();
 		isShowNote = MyPreferences.isShowNote();
+		isShowTags = MyPreferences.isShowTags();
 		isShowTakePicture = MyPreferences.isShowTakePicture();
 		isShowIsCCardPayment = MyPreferences.isShowIsCCardPayment();
 		isOpenCalculatorForTemplates = MyPreferences.isOpenCalculatorForTemplates();
@@ -384,6 +390,21 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 			}
 		}
 
+		if (intent != null) {
+			List<String> intentTags = IntentTransactionProcessor.extractTagsFromIntent(intent);
+			if (!intentTags.isEmpty()) {
+				for (String tag : intentTags) {
+					db.findOrInsertEntityByTitle(Tag.class, tag);
+				}
+				String intentTagsStr = String.join(", ", intentTags);
+				transaction.tags = intentTagsStr;
+				if (isShowTags && tagSelector != null) {
+					tagSelector.setSelectedTags(intentTagsStr);
+					tagSelector.fetchEntities();
+				}
+			}
+		}
+
 		if (isShowTakePicture) {
 			pickMedia =
 					registerForActivityResult(new ActivityResultContracts.PickVisualMedia(), uri -> {
@@ -420,6 +441,11 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		}
 		payeeSelector.createNode(layout);
 		payeeSelector.fetchEntities();
+	}
+
+	protected void createTagsNode(LinearLayout layout) {
+		tagSelector = new TagSelector<>(this, db, x);
+		tagSelector.createNode(layout);
 	}
 
 	protected abstract void fetchCategories();
@@ -470,7 +496,8 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		int locationOrder = MyPreferences.getLocationOrder();
 		int noteOrder = MyPreferences.getNoteOrder();
 		int projectOrder = MyPreferences.getProjectOrder();
-		for (int i = 0; i < 6; i++) {
+		int tagsOrder = MyPreferences.getTagsOrder();
+		for (int i = 0; i < 7; i++) {
 			if (i == locationOrder) {
 				locationSelector.createNode(layout);
 			}
@@ -486,6 +513,11 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 			}
 			if (i == projectOrder) {
 				projectSelector.createNode(layout);
+			}
+			if (i == tagsOrder) {
+				if (isShowTags) {
+					createTagsNode(layout);
+				}
 			}
 		}
 		if (isShowTakePicture && transaction.isNotTemplateLike()) {
@@ -518,6 +550,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		projectSelector.onClick(id);
 		categorySelector.onClick(id);
 		locationSelector.onClick(id);
+		if (tagSelector != null) tagSelector.onClick(id);
 
 		if (id == R.id.account) {
 			x.select(this, R.id.account, R.string.account, accountCursor, accountAdapter,
@@ -752,6 +785,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		if (locationSelector != null) locationSelector.setEnabled(enabled);
 		if (payeeSelector != null) payeeSelector.setEnabled(enabled);
 		if (noteText != null) noteText.setEnabled(enabled);
+		if (tagSelector != null) tagSelector.setEnabled(enabled);
 		if (pictureTopView != null) pictureTopView.setEnabled(enabled);
 		if (ccardPayment != null) ((View) ccardPayment.getTag()).setEnabled(enabled);
 		rateView.setEnabled(enabled);
@@ -774,6 +808,9 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		setDateTime(transaction.dateTime);
 		if (isShowNote) {
 			noteText.setText(transaction.note);
+		}
+		if (isShowTags && tagSelector != null) {
+			tagSelector.setSelectedTags(transaction.tags);
 		}
 		if (transaction.isTemplate()) {
 			templateName.setText(transaction.templateName);
@@ -832,6 +869,9 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		if (isShowNote) {
 			transaction.note = text(noteText);
 		}
+		if (isShowTags && tagSelector != null) {
+			transaction.tags = tagSelector.getSelectedTags();
+		}
 		if (transaction.isTemplate()) {
 			transaction.templateName = text(templateName);
 		}
@@ -862,6 +902,7 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
 		if (projectSelector != null) projectSelector.onDestroy();
 		if (locationSelector != null) locationSelector.onDestroy();
 		if (categorySelector != null) categorySelector.onDestroy();
+		if (tagSelector != null) tagSelector.onDestroy();
 		super.onDestroy();
 	}
 

--- a/app/src/main/java/tw/tib/financisto/activity/BlotterFilterActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/BlotterFilterActivity.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.TreeSet;
 
 import static tw.tib.financisto.blotter.BlotterFilter.FROM_ACCOUNT_ID;
 
@@ -54,6 +55,7 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 	private TextView account;
 	private TextView currency;
 	private TextView note;
+	private TextView tags;
 	private TextView status;
 	private TextView split;
 	private TextView sortOrder;
@@ -92,6 +94,7 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 		initProjectSelector(layout);
 		initLocationSelector(layout);
 		note = x.addFilterNodeMinus(layout, R.id.note, R.id.note_clear, R.string.note, R.string.no_filter);
+		tags = x.addFilterNodeMinus(layout, R.id.tags, R.id.tags_clear, R.string.tags, R.string.no_filter);
 		status = x.addFilterNodeMinus(layout, R.id.status, R.id.status_clear, R.string.transaction_status, R.string.no_filter);
 		split = x.addFilterNodeMinus(layout, R.id.split, R.id.split_clear, R.string.filter_split, R.string.filter_split_default);
 		if (!isPlannerFilter) {
@@ -135,6 +138,7 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 			updateProjectFromFilter();
 			updatePayeeFromFilter();
 			updateNoteFromFilter();
+			updateTagsFromFilter();
 			updateLocationFromFilter();
 			updateSortOrderFromFilter();
 			updateStatusFromFilter();
@@ -210,6 +214,69 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 		}
 	}
 
+	private void updateTagsFromFilter() {
+		List<String> selectedTags = getSelectedTagsFromFilter();
+		if (!selectedTags.isEmpty()) {
+			tags.setText(String.join(", ", selectedTags));
+			showMinusButton(tags);
+		} else {
+			tags.setText(R.string.no_filter);
+			hideMinusButton(tags);
+		}
+	}
+
+	private List<String> getSelectedTagsFromFilter() {
+		List<String> list = new ArrayList<>();
+		Criterion c = filter.get(BlotterFilter.TAGS);
+		if (c != null) {
+			extractTagsFromCriterion(c, list);
+		}
+		return list;
+	}
+
+	private void extractTagsFromCriterion(Criterion c, List<String> list) {
+		if (c.getChildren() != null && c.getChildren().length > 0) {
+			for (Criterion child : c.getChildren()) {
+				extractTagsFromCriterion(child, list);
+			}
+		} else if (c.getValues() != null) {
+			for (String v : c.getValues()) {
+				if (v != null) {
+					if (v.startsWith("%") && v.endsWith("%") && v.length() >= 2) {
+						v = v.substring(1, v.length() - 1);
+					}
+					v = v.trim();
+					if (!v.isEmpty() && !list.contains(v)) {
+						list.add(v);
+					}
+				}
+			}
+		}
+	}
+
+	private void showTagsFilterDialog() {
+		var allTagsSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+		allTagsSet.addAll(db.getAllUniqueTags());
+		allTagsSet.addAll(getSelectedTagsFromFilter());
+		if (allTagsSet.isEmpty()) {
+			Toast.makeText(this, R.string.no_tags, Toast.LENGTH_SHORT).show();
+			return;
+		}
+
+		var items = new ArrayList<TagMultiChoiceItem>();
+		var selected = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+		selected.addAll(getSelectedTagsFromFilter());
+
+		for (String tag : allTagsSet) {
+			var item = new TagMultiChoiceItem(tag);
+			if (selected.contains(tag)) {
+				item.setChecked(true);
+			}
+			items.add(item);
+		}
+		x.selectMultiChoice(this, R.id.tags, R.string.tags, items);
+	}
+
 	private void updateStatusFromFilter() {
 		Criterion c = filter.get(BlotterFilter.STATUS);
 		if (c != null) {
@@ -281,6 +348,10 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 			startActivityForResult(intent, REQUEST_NOTE_FILTER);
 		} else if (id == R.id.note_clear) {
 			clear(BlotterFilter.NOTE, note);
+		} else if (id == R.id.tags) {
+			showTagsFilterDialog();
+		} else if (id == R.id.tags_clear) {
+			clear(BlotterFilter.TAGS, tags);
 		} else if (id == R.id.sort_order) {
 			ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, sortBlotterEntries);
 			int selectedPos = BlotterFilter.SORT_OLDER_TO_NEWER.equals(filter.getSortOrder()) ? 1 : 0;
@@ -371,6 +442,27 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 				clear(BlotterFilter.STATUS, status);
 			}
 			updateStatusFromFilter();
+		} else if (id == R.id.tags) {
+			var selectedTags = new ArrayList<String>();
+			for (var item : items) {
+				if (item.isChecked()) {
+					selectedTags.add(((TagMultiChoiceItem) item).tag);
+				}
+			}
+			if (!selectedTags.isEmpty()) {
+				if (selectedTags.size() == 1) {
+					filter.put(new Criterion(BlotterFilter.TAGS, WhereFilter.Operation.LIKE, "%" + selectedTags.get(0) + "%"));
+				} else {
+					Criterion[] children = new Criterion[selectedTags.size()];
+					for (int i = 0; i < selectedTags.size(); i++) {
+						children[i] = new Criterion(BlotterFilter.TAGS, WhereFilter.Operation.LIKE, "%" + selectedTags.get(i) + "%");
+					}
+					filter.put(Criterion.or(children));
+				}
+			} else {
+				clear(BlotterFilter.TAGS, tags);
+			}
+			updateTagsFromFilter();
 		}
 	}
 
@@ -418,6 +510,35 @@ public class BlotterFilterActivity extends FilterAbstractActivity {
 		@Override
 		public String getTitle() {
 			return this.title;
+		}
+
+		@Override
+		public boolean isChecked() {
+			return isChecked;
+		}
+
+		@Override
+		public void setChecked(boolean checked) {
+			isChecked = checked;
+		}
+	}
+
+	static class TagMultiChoiceItem implements MultiChoiceItem {
+		public final String tag;
+		private boolean isChecked;
+
+		public TagMultiChoiceItem(String tag) {
+			this.tag = tag;
+		}
+
+		@Override
+		public long getId() {
+			return 0;
+		}
+
+		@Override
+		public String getTitle() {
+			return tag;
 		}
 
 		@Override

--- a/app/src/main/java/tw/tib/financisto/activity/MenuListItem.java
+++ b/app/src/main/java/tw/tib/financisto/activity/MenuListItem.java
@@ -225,6 +225,7 @@ public enum MenuListItem implements SummaryEntityEnum {
         CURRENCIES(R.string.currencies, R.drawable.ic_action_money, CurrencyListActivity.class),
         EXCHANGE_RATES(R.string.exchange_rates, R.drawable.ic_action_line_chart, ExchangeRatesListActivity.class),
         CATEGORIES(R.string.categories, R.drawable.ic_action_category, CategoryListActivity2.class),
+        TAGS(R.string.tags, R.drawable.ic_action_tag, TagListActivity.class),
         SMS_TEMPLATES(R.string.sms_templates, R.drawable.ic_action_sms, SmsDragListActivity.class, BIND_NOTIFICATION_LISTENER_SERVICE),
         PAYEES(R.string.payees, R.drawable.ic_action_users, PayeeListActivity.class),
         PROJECTS(R.string.projects, R.drawable.ic_action_gear, ProjectListActivity.class),

--- a/app/src/main/java/tw/tib/financisto/activity/TagActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TagActivity.java
@@ -1,0 +1,11 @@
+package tw.tib.financisto.activity;
+
+import tw.tib.financisto.model.Tag;
+
+public class TagActivity extends MyEntityActivity<Tag> {
+
+    public TagActivity() {
+        super(Tag.class);
+    }
+
+}

--- a/app/src/main/java/tw/tib/financisto/activity/TagListActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TagListActivity.java
@@ -1,0 +1,30 @@
+package tw.tib.financisto.activity;
+
+import android.view.View;
+import tw.tib.financisto.R;
+import tw.tib.financisto.blotter.BlotterFilter;
+import tw.tib.financisto.filter.Criterion;
+import tw.tib.financisto.model.Tag;
+
+public class TagListActivity extends MyEntityListActivity<Tag> {
+
+    public TagListActivity() {
+        super(Tag.class, R.string.no_tags);
+    }
+
+    @Override
+    protected Class<? extends MyEntityActivity> getEditActivityClass() {
+        return TagActivity.class;
+    }
+
+    @Override
+    protected Criterion createBlotterCriteria(Tag t) {
+        return Criterion.like(BlotterFilter.TAGS, "%" + t.title + "%");
+    }
+
+    @Override
+    protected void deleteItem(View v, int position, long id) {
+        db.deleteTag(id);
+        recreateCursor();
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/activity/TagSelector.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TagSelector.java
@@ -289,13 +289,13 @@ public class TagSelector<A extends AbstractActivity> {
         if (selectedTags.isEmpty()) {
             return null;
         }
-        return String.join(", ", selectedTags);
+        return String.join("\n", selectedTags);
     }
 
     public void setSelectedTags(String tagsString) {
         selectedTags.clear();
         if (!Utils.isEmpty(tagsString)) {
-            for (String t : tagsString.split("[,;]")) {
+            for (String t : tagsString.split("\n")) {
                 String trimmed = t.trim();
                 if (!trimmed.isEmpty()) {
                     selectedTags.add(trimmed);

--- a/app/src/main/java/tw/tib/financisto/activity/TagSelector.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TagSelector.java
@@ -1,0 +1,320 @@
+package tw.tib.financisto.activity;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.ToggleButton;
+
+import androidx.core.util.Pair;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import tw.tib.financisto.Application;
+import tw.tib.financisto.R;
+import tw.tib.financisto.db.DatabaseAdapter;
+import tw.tib.financisto.model.Tag;
+import tw.tib.financisto.utils.MyPreferences;
+import tw.tib.financisto.utils.Utils;
+import tw.tib.financisto.view.PillSpan;
+
+public class TagSelector<A extends AbstractActivity> {
+
+    private final A activity;
+    private final DatabaseAdapter db;
+    private final ActivityLayout x;
+    private final boolean isShow;
+
+    private View node;
+    private TextView text;
+    private AutoCompleteTextView autoCompleteFilter;
+    private final Set<String> selectedTags = new LinkedHashSet<>();
+    private List<Tag> entities = new ArrayList<>();
+    private boolean enabled = true;
+    private boolean loaded = false;
+
+    public TagSelector(A activity, DatabaseAdapter db, ActivityLayout x) {
+        this.activity = activity;
+        this.db = db;
+        this.x = x;
+        this.isShow = MyPreferences.isShowTags();
+    }
+
+    public TextView createNode(LinearLayout layout) {
+        if (!isShow) {
+            return null;
+        }
+
+        Pair<TextView, AutoCompleteTextView> views = x.addListNodeWithButtonsAndFilter(
+                layout,
+                R.layout.select_entry_with_2btn_and_filter,
+                R.id.tags,
+                R.id.tags_add,
+                R.id.tags_clear,
+                R.string.tags,
+                R.string.select_tags,
+                R.id.tags_filter_toggle
+        );
+
+        text = views.first;
+        autoCompleteFilter = views.second;
+        node = (View) text.getTag();
+        node.setEnabled(false);
+
+        float density = activity.getResources().getDisplayMetrics().density;
+        int minHeight = (int) (56 * density);
+        node.setMinimumHeight(minHeight);
+        View row = node.findViewById(R.id.list_node_row);
+        if (row != null) {
+            row.setMinimumHeight(minHeight);
+        }
+        View parent = (View) text.getParent();
+        if (parent != null) {
+            parent.setPadding(parent.getPaddingLeft(), (int) (4 * density), parent.getPaddingRight(), (int) (4 * density));
+        }
+        text.setPadding(0, (int) (2 * density), 0, (int) (2 * density));
+        text.setLineSpacing(3 * density, 1.0f);
+
+        initAutoCompleteFilter(autoCompleteFilter);
+        fetchEntities();
+
+        return text;
+    }
+
+    private void initAutoCompleteFilter(final AutoCompleteTextView filterTxt) {
+        if (filterTxt == null) return;
+        filterTxt.setInputType(InputType.TYPE_CLASS_TEXT
+                | InputType.TYPE_TEXT_FLAG_CAP_WORDS
+                | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+                | InputType.TYPE_TEXT_VARIATION_FILTER);
+        filterTxt.setThreshold(1);
+
+        filterTxt.setOnFocusChangeListener((view, hasFocus) -> {
+            if (hasFocus) {
+                List<String> tags = db.getAllUniqueTags();
+                ArrayAdapter<String> adapter = new ArrayAdapter<>(activity,
+                        android.R.layout.simple_dropdown_item_1line, tags);
+                filterTxt.setAdapter(adapter);
+                filterTxt.selectAll();
+            }
+        });
+
+        filterTxt.setOnItemClickListener((parent, view, position, id) -> {
+            String tag = (String) parent.getItemAtPosition(position);
+            if (!TextUtils.isEmpty(tag)) {
+                selectedTags.add(tag.trim());
+                fillCheckedEntitiesInUI();
+            }
+            filterTxt.setText("");
+            View toggleBtn = (View) filterTxt.getTag();
+            if (toggleBtn != null) {
+                toggleBtn.performClick();
+            }
+        });
+    }
+
+    public void fetchEntities() {
+        synchronized (this) {
+            loaded = false;
+        }
+        Application.getExecutor().execute(() -> {
+            List<Tag> list = db.getAllEntitiesList(Tag.class, false, true);
+            // Also ensure any tags from transactions exist in list
+            List<String> uniqueTagNames = db.getAllUniqueTags();
+            Set<String> known = new LinkedHashSet<>();
+            for (Tag t : list) {
+                known.add(t.title.toLowerCase());
+            }
+            for (String name : uniqueTagNames) {
+                if (!known.contains(name.toLowerCase())) {
+                    Tag t = new Tag(name);
+                    list.add(t);
+                    known.add(name.toLowerCase());
+                }
+            }
+
+            synchronized (TagSelector.this) {
+                entities = list;
+                loaded = true;
+            }
+
+            activity.runOnUiThread(() -> {
+                if (node != null && enabled) {
+                    node.setEnabled(true);
+                }
+                fillCheckedEntitiesInUI();
+            });
+        });
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        if (node != null) {
+            node.setEnabled(enabled);
+        }
+    }
+
+    public void onClick(int id) {
+        if (!enabled) return;
+
+        if (id == R.id.tags) {
+            pickTags();
+        } else if (id == R.id.tags_add) {
+            showAddTagDialog();
+        } else if (id == R.id.tags_clear) {
+            clearSelection();
+        }
+    }
+
+    public void clearSelection() {
+        selectedTags.clear();
+        fillCheckedEntitiesInUI();
+    }
+
+    public void pickTags() {
+        List<Tag> currentTags;
+        synchronized (this) {
+            currentTags = new ArrayList<>(entities);
+        }
+
+        final String[] titles = new String[currentTags.size()];
+        final boolean[] checked = new boolean[currentTags.size()];
+
+        for (int i = 0; i < currentTags.size(); i++) {
+            titles[i] = currentTags.get(i).title;
+            checked[i] = containsIgnoreCase(selectedTags, titles[i]);
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        builder.setTitle(R.string.tags);
+
+        if (currentTags.isEmpty()) {
+            builder.setMessage(R.string.no_tags);
+            builder.setPositiveButton(R.string.new_tag, (dialog, which) -> showAddTagDialog());
+            builder.setNegativeButton(R.string.cancel, null);
+        } else {
+            builder.setMultiChoiceItems(titles, checked, (dialog, which, isChecked) -> {
+                checked[which] = isChecked;
+            });
+            builder.setPositiveButton(R.string.ok, (dialog, which) -> {
+                selectedTags.clear();
+                for (int i = 0; i < checked.length; i++) {
+                    if (checked[i]) {
+                        selectedTags.add(titles[i]);
+                    }
+                }
+                fillCheckedEntitiesInUI();
+            });
+            builder.setNeutralButton(R.string.new_tag, (dialog, which) -> {
+                selectedTags.clear();
+                for (int i = 0; i < checked.length; i++) {
+                    if (checked[i]) {
+                        selectedTags.add(titles[i]);
+                    }
+                }
+                fillCheckedEntitiesInUI();
+                showAddTagDialog();
+            });
+            builder.setNegativeButton(R.string.cancel, null);
+        }
+        builder.show();
+    }
+
+    public void showAddTagDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        builder.setTitle(R.string.new_tag);
+
+        final EditText input = new EditText(activity);
+        input.setSingleLine(true);
+        input.setHint(R.string.enter_tag_name);
+
+        FrameLayout container = new FrameLayout(activity);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        int margin = (int) (16 * activity.getResources().getDisplayMetrics().density);
+        params.leftMargin = margin;
+        params.rightMargin = margin;
+        input.setLayoutParams(params);
+        container.addView(input);
+        builder.setView(container);
+
+        builder.setPositiveButton(R.string.ok, (dialog, which) -> {
+            String tagName = input.getText().toString().trim();
+            if (!TextUtils.isEmpty(tagName)) {
+                // Save to DB
+                Tag t = db.findOrInsertEntityByTitle(Tag.class, tagName);
+                selectedTags.add(t.title);
+                fetchEntities();
+            }
+        });
+        builder.setNegativeButton(R.string.cancel, null);
+        builder.show();
+    }
+
+    public void fillCheckedEntitiesInUI() {
+        if (text == null) return;
+
+        if (selectedTags.isEmpty()) {
+            text.setText(R.string.select_tags);
+            showHideMinusBtn(false);
+        } else {
+            String commaSeparated = String.join(", ", selectedTags);
+            text.setText(PillSpan.formatAsPills(activity, commaSeparated));
+            showHideMinusBtn(true);
+        }
+    }
+
+    private void showHideMinusBtn(boolean show) {
+        if (text != null) {
+            ImageView minusBtn = (ImageView) text.getTag(R.id.bMinus);
+            if (minusBtn != null) {
+                minusBtn.setVisibility(show ? View.VISIBLE : View.GONE);
+            }
+        }
+    }
+
+    public String getSelectedTags() {
+        if (selectedTags.isEmpty()) {
+            return null;
+        }
+        return String.join(", ", selectedTags);
+    }
+
+    public void setSelectedTags(String tagsString) {
+        selectedTags.clear();
+        if (!Utils.isEmpty(tagsString)) {
+            for (String t : tagsString.split("[,;]")) {
+                String trimmed = t.trim();
+                if (!trimmed.isEmpty()) {
+                    selectedTags.add(trimmed);
+                }
+            }
+        }
+        fillCheckedEntitiesInUI();
+    }
+
+    private static boolean containsIgnoreCase(Set<String> set, String target) {
+        for (String s : set) {
+            if (s.equalsIgnoreCase(target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void onDestroy() {
+        // cleanup if needed
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/activity/TransactionActivity.java
+++ b/app/src/main/java/tw/tib/financisto/activity/TransactionActivity.java
@@ -748,7 +748,7 @@ public class TransactionActivity extends AbstractTransactionActivity {
         Category category = db.getCategory(split.categoryId);
         String payee = split.payeeId < 1 ? null : db.get(Payee.class, split.payeeId).title;
         label.setText(transactionTitleUtils.generateTransactionTitle(
-                false, payee, null, split.note, null,
+                false, payee, null, split.note, split.tags, null,
                 split.categoryId, category.title));
         Currency currency = getCurrency();
         u.setAmountText(data, currency, split.fromAmount, false);
@@ -770,7 +770,7 @@ public class TransactionActivity extends AbstractTransactionActivity {
         Category category = db.getCategory(split.categoryId);
         label.setText(transactionTitleUtils.generateTransactionTitle(
                 true, null, u.getTransferTitleText(fromAccount, toAccount),
-                split.note, null, split.categoryId, split.categoryId == 0 ? "" : category.title));
+                split.note, split.tags, null, split.categoryId, split.categoryId == 0 ? "" : category.title));
         //u.setTransferTitleText(label, fromAccount, toAccount);
         u.setTransferAmountText(data, fromAccount.currency, split.fromAmount, toAccount.currency, split.toAmount);
     }

--- a/app/src/main/java/tw/tib/financisto/adapter/BlotterListAdapter.java
+++ b/app/src/main/java/tw/tib/financisto/adapter/BlotterListAdapter.java
@@ -183,11 +183,12 @@ public class BlotterListAdapter extends ResourceCursorAdapter {
             String fromAccountTitle = cursor.getString(BlotterColumns.from_account_title.ordinal());
             String toAccountTitle = cursor.getString(BlotterColumns.to_account_title.ordinal());
             String note = cursor.getString(BlotterColumns.note.ordinal());
+            String tags = cursor.getString(BlotterColumns.tags.ordinal());
             long categoryId = cursor.getLong(BlotterColumns.category_id.ordinal());
             String category = getCategoryTitle(cursor, categoryId);
 
             CharSequence text = transactionTitleUtils.generateTransactionTitle(true,
-                    null, u.getTransferTitleText(fromAccountTitle, toAccountTitle), note,
+                    null, u.getTransferTitleText(fromAccountTitle, toAccountTitle), note, tags,
                     null, categoryId, category);
             noteView.setText(text);
             noteView.setTextColor(Color.WHITE);
@@ -320,11 +321,12 @@ public class BlotterListAdapter extends ResourceCursorAdapter {
         sb.setLength(0);
         String payee = cursor.getString(BlotterColumns.payee.ordinal());
         String note = cursor.getString(BlotterColumns.note.ordinal());
+        String tags = cursor.getString(BlotterColumns.tags.ordinal());
         long locationId = cursor.getLong(BlotterColumns.location_id.ordinal());
         String location = getLocationTitle(cursor, locationId);
         long categoryId = cursor.getLong(BlotterColumns.category_id.ordinal());
         String category = getCategoryTitle(cursor, categoryId);
-        CharSequence text = transactionTitleUtils.generateTransactionTitle(false, payee, null, note, location, categoryId, category);
+        CharSequence text = transactionTitleUtils.generateTransactionTitle(false, payee, null, note, tags, location, categoryId, category);
         noteView.setText(text);
         noteView.setTextColor(Color.WHITE);
     }

--- a/app/src/main/java/tw/tib/financisto/adapter/ScheduledListAdapter.java
+++ b/app/src/main/java/tw/tib/financisto/adapter/ScheduledListAdapter.java
@@ -151,7 +151,7 @@ public class ScheduledListAdapter extends BaseAdapter {
 				category = t.category.title;
 			}
             String payee = t.payee != null ? t.payee.title : null;
-            CharSequence text = transactionTitleUtils.generateTransactionTitle(false, payee, null, note, location, t.category.id, category);
+            CharSequence text = transactionTitleUtils.generateTransactionTitle(false, payee, null, note, t.tags, location, t.category.id, category);
             noteView.setText(text);
 			noteView.setTextColor(Color.WHITE);
 

--- a/app/src/main/java/tw/tib/financisto/adapter/TransactionsListAdapter.java
+++ b/app/src/main/java/tw/tib/financisto/adapter/TransactionsListAdapter.java
@@ -99,7 +99,8 @@ public class TransactionsListAdapter extends BlotterListAdapter {
         if (categoryId != 0) {
             category = cursor.getString(BlotterColumns.category_title.ordinal());
         }
-        CharSequence text = transactionTitleUtils.generateTransactionTitle(toAccountId > 0, payee, transfer, note, location, categoryId, category);
+        String tags = cursor.getString(BlotterColumns.tags.ordinal());
+        CharSequence text = transactionTitleUtils.generateTransactionTitle(toAccountId > 0, payee, transfer, note, tags, location, categoryId, category);
         v.centerView.setText(text);
         sb.setLength(0);
 

--- a/app/src/main/java/tw/tib/financisto/backup/Backup.java
+++ b/app/src/main/java/tw/tib/financisto/backup/Backup.java
@@ -22,6 +22,7 @@ import static tw.tib.financisto.db.DatabaseHelper.LOCATIONS_TABLE;
 import static tw.tib.financisto.db.DatabaseHelper.PAYEE_TABLE;
 import static tw.tib.financisto.db.DatabaseHelper.PROJECT_TABLE;
 import static tw.tib.financisto.db.DatabaseHelper.SMS_TEMPLATES_TABLE;
+import static tw.tib.financisto.db.DatabaseHelper.TAG_TABLE;
 import static tw.tib.financisto.db.DatabaseHelper.TRANSACTION_ATTRIBUTE_TABLE;
 import static tw.tib.financisto.db.DatabaseHelper.TRANSACTION_TABLE;
 
@@ -32,6 +33,7 @@ public final class Backup {
 			TRANSACTION_ATTRIBUTE_TABLE, BUDGET_TABLE, CATEGORY_TABLE,
 			CURRENCY_TABLE, LOCATIONS_TABLE, PROJECT_TABLE, TRANSACTION_TABLE,
 			PAYEE_TABLE, CCARD_CLOSING_DATE_TABLE, SMS_TEMPLATES_TABLE,
+			TAG_TABLE,
 			"split", /* todo: seems not used, found only in old 20110422_0051_create_split_table.sql, should be removed then */
 			EXCHANGE_RATES_TABLE};
 
@@ -39,7 +41,7 @@ public final class Backup {
 			ATTRIBUTES_TABLE, CATEGORY_TABLE, PROJECT_TABLE, LOCATIONS_TABLE};
 
 	public static final String[] BACKUP_TABLES_WITH_SORT_ORDER = {
-			ACCOUNT_TABLE, SMS_TEMPLATES_TABLE, PROJECT_TABLE, PAYEE_TABLE, BUDGET_TABLE, CURRENCY_TABLE, LOCATIONS_TABLE, ATTRIBUTES_TABLE};
+			ACCOUNT_TABLE, SMS_TEMPLATES_TABLE, PROJECT_TABLE, PAYEE_TABLE, BUDGET_TABLE, CURRENCY_TABLE, LOCATIONS_TABLE, ATTRIBUTES_TABLE, TAG_TABLE};
 
 	public static final String[] RESTORE_SCRIPTS = {
 			"20100114_1158_alter_accounts_types.sql",

--- a/app/src/main/java/tw/tib/financisto/backup/DatabaseExport.java
+++ b/app/src/main/java/tw/tib/financisto/backup/DatabaseExport.java
@@ -16,6 +16,7 @@ import static tw.tib.financisto.backup.Backup.tableHasSystemIds;
 import static tw.tib.financisto.db.DatabaseHelper.ACCOUNT_TABLE;
 import static tw.tib.orb.EntityManager.ALIASES_COL;
 import static tw.tib.orb.EntityManager.DEF_SORT_COL;
+import tw.tib.financisto.db.DatabaseHelper;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -110,7 +111,7 @@ public class DatabaseExport extends Export {
 						if (value != null) {
 							bw.write(colName);
 							bw.write(":");
-							bw.write((backupNewlines || colName.equals(ALIASES_COL)) ? escape(sb, value) : removeNewLine(value));
+							bw.write((backupNewlines || colName.equals(ALIASES_COL) || colName.equals(DatabaseHelper.TransactionColumns.tags.name())) ? escape(sb, value) : removeNewLine(value));
 							bw.write("\n");
 						}
 					}

--- a/app/src/main/java/tw/tib/financisto/backup/DatabaseImport.java
+++ b/app/src/main/java/tw/tib/financisto/backup/DatabaseImport.java
@@ -37,6 +37,7 @@ import static tw.tib.financisto.db.DatabaseHelper.ATTRIBUTES_TABLE;
 import static tw.tib.financisto.db.DatabaseHelper.LOCATIONS_TABLE;
 import static tw.tib.orb.EntityManager.ALIASES_COL;
 import static tw.tib.orb.EntityManager.DEF_SORT_COL;
+import tw.tib.financisto.db.DatabaseHelper;
 
 public class DatabaseImport extends FullDatabaseImport {
 
@@ -133,7 +134,7 @@ public class DatabaseImport extends FullDatabaseImport {
                     int i = line.indexOf(":");
                     if (i > 0) {
                         String columnName = line.substring(0, i);
-                        String value = (backupNewlines || columnName.equals(ALIASES_COL)) ? unescape(sb, line.substring(i + 1)) : line.substring(i + 1);
+                        String value = (backupNewlines || columnName.equals(ALIASES_COL) || columnName.equals(DatabaseHelper.TransactionColumns.tags.name())) ? unescape(sb, line.substring(i + 1)) : line.substring(i + 1);
                         values.put(columnName, value);
                     }
                 }

--- a/app/src/main/java/tw/tib/financisto/blotter/BlotterFilter.java
+++ b/app/src/main/java/tw/tib/financisto/blotter/BlotterFilter.java
@@ -25,6 +25,7 @@ public interface BlotterFilter {
 	String PAYEE = BlotterColumns.payee.name();
 	String PAYEE_ID = BlotterColumns.payee_id.name();
 	String NOTE = BlotterColumns.note.name();
+	String TAGS = BlotterColumns.tags.name();
 	String TEMPLATE_NAME = BlotterColumns.template_name.name();
 	String DATETIME = BlotterColumns.datetime.name();
 	String BUDGET_ID = "budget_id";

--- a/app/src/main/java/tw/tib/financisto/db/Database.java
+++ b/app/src/main/java/tw/tib/financisto/db/Database.java
@@ -14,6 +14,6 @@ public interface Database {
 
 	String DATABASE_NAME = "financisto.db";
 
-	int DATABASE_VERSION = 247;
+	int DATABASE_VERSION = 249;
 
 }

--- a/app/src/main/java/tw/tib/financisto/db/DatabaseAdapter.java
+++ b/app/src/main/java/tw/tib/financisto/db/DatabaseAdapter.java
@@ -1348,6 +1348,40 @@ public class DatabaseAdapter extends MyEntityManager {
         return new Attribute();
     }
 
+    public List<String> getAllUniqueTags() {
+        TreeSet<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        try (Cursor c = db().rawQuery("SELECT title FROM " + DatabaseHelper.TAG_TABLE + " WHERE is_active=1", null)) {
+            while (c.moveToNext()) {
+                String title = c.getString(0);
+                if (title != null && !title.trim().isEmpty()) {
+                    set.add(title.trim());
+                }
+            }
+        } catch (Exception e) {
+            // tag table might not exist yet during migration
+        }
+        try (Cursor c = db().rawQuery("SELECT DISTINCT tags FROM " + DatabaseHelper.TRANSACTION_TABLE + " WHERE tags IS NOT NULL AND tags != ''", null)) {
+            while (c.moveToNext()) {
+                String raw = c.getString(0);
+                if (raw != null) {
+                    for (String t : raw.split(",")) {
+                        String trimmed = t.trim();
+                        if (!trimmed.isEmpty()) {
+                            set.add(trimmed);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get unique tags", e);
+        }
+        return new ArrayList<>(set);
+    }
+
+    public void deleteTag(long id) {
+        delete(tw.tib.financisto.model.Tag.class, id);
+    }
+
     public long insertOrUpdate(Attribute attribute) {
         if (attribute.id == -1) {
             return insertAttribute(attribute);

--- a/app/src/main/java/tw/tib/financisto/db/DatabaseAdapter.java
+++ b/app/src/main/java/tw/tib/financisto/db/DatabaseAdapter.java
@@ -1364,7 +1364,7 @@ public class DatabaseAdapter extends MyEntityManager {
             while (c.moveToNext()) {
                 String raw = c.getString(0);
                 if (raw != null) {
-                    for (String t : raw.split(",")) {
+                    for (String t : raw.split("\n")) {
                         String trimmed = t.trim();
                         if (!trimmed.isEmpty()) {
                             set.add(trimmed);

--- a/app/src/main/java/tw/tib/financisto/db/DatabaseHelper.java
+++ b/app/src/main/java/tw/tib/financisto/db/DatabaseHelper.java
@@ -49,6 +49,7 @@ public class DatabaseHelper extends DatabaseSchemaEvolution {
     public static final String CCARD_CLOSING_DATE_TABLE = "ccard_closing_date";
     public static final String EXCHANGE_RATES_TABLE = "currency_exchange_rate";
     public static final String DELETE_LOG_TABLE = "delete_log";
+    public static final String TAG_TABLE = "tag";
 
     public static final String V_ALL_TRANSACTIONS = "v_all_transactions";
     public static final String V_BLOTTER = "v_blotter";
@@ -95,7 +96,8 @@ public class DatabaseHelper extends DatabaseSchemaEvolution {
         attached_picture,
         is_ccard_payment,
         last_recurrence,
-        blob_key;
+        blob_key,
+        tags;
 
         public static String[] NORMAL_PROJECTION = EnumUtils.asStringArray(TransactionColumns.values());
 
@@ -138,7 +140,8 @@ public class DatabaseHelper extends DatabaseSchemaEvolution {
         last_recurrence,
         from_account_balance,
         to_account_balance,
-        is_transfer;
+        is_transfer,
+        tags;
 
         public static final String[] NORMAL_PROJECTION = EnumUtils.asStringArray(BlotterColumns.values());
 

--- a/app/src/main/java/tw/tib/financisto/model/Tag.java
+++ b/app/src/main/java/tw/tib/financisto/model/Tag.java
@@ -1,0 +1,32 @@
+package tw.tib.financisto.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import static tw.tib.financisto.db.DatabaseHelper.TAG_TABLE;
+import static tw.tib.orb.EntityManager.DEF_SORT_COL;
+
+@Entity
+@Table(name = TAG_TABLE)
+public class Tag extends MyEntity implements SortableEntity {
+
+    @Column(name = DEF_SORT_COL)
+    public long sortOrder;
+
+    @Column(name = "updated_on")
+    public long updatedOn;
+
+    public Tag() {
+    }
+
+    public Tag(String title) {
+        this.title = title;
+        this.isActive = true;
+    }
+
+    @Override
+    public long getSortOrder() {
+        return sortOrder;
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/model/Transaction.java
+++ b/app/src/main/java/tw/tib/financisto/model/Transaction.java
@@ -102,6 +102,7 @@ public class Transaction extends TransactionBase {
 		values.put(TransactionColumns.is_ccard_payment.name(), isCCardPayment);
 		values.put(TransactionColumns.last_recurrence.name(), lastRecurrence);
 		values.put(TransactionColumns.blob_key.name(), blobKey);
+		values.put(TransactionColumns.tags.name(), tags);
 		return values;
 	}
 
@@ -145,6 +146,7 @@ public class Transaction extends TransactionBase {
 		t.lastRecurrence = c.getLong(BlotterColumns.last_recurrence.ordinal());
 		t.fromAccountBalance = c.getLong(BlotterColumns.from_account_balance.ordinal());
 		t.toAccountBalance = c.getLong(BlotterColumns.to_account_balance.ordinal());
+		t.tags = c.getString(BlotterColumns.tags.ordinal());
 		return t;
 	}
 

--- a/app/src/main/java/tw/tib/financisto/model/TransactionBase.java
+++ b/app/src/main/java/tw/tib/financisto/model/TransactionBase.java
@@ -41,6 +41,9 @@ public abstract class TransactionBase implements Serializable, Cloneable {
 	@Column(name = "note")
 	public String note;
 
+	@Column(name = "tags")
+	public String tags;
+
     @Column(name = "original_from_amount")
     public long originalFromAmount;
 

--- a/app/src/main/java/tw/tib/financisto/service/IntentTransactionProcessor.java
+++ b/app/src/main/java/tw/tib/financisto/service/IntentTransactionProcessor.java
@@ -8,6 +8,8 @@ import android.util.Log;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import tw.tib.financisto.db.DatabaseAdapter;
@@ -15,6 +17,7 @@ import tw.tib.financisto.model.Account;
 import tw.tib.financisto.model.Category;
 import tw.tib.financisto.model.Payee;
 import tw.tib.financisto.model.Project;
+import tw.tib.financisto.model.Tag;
 import tw.tib.financisto.model.Transaction;
 import tw.tib.financisto.model.TransactionStatus;
 
@@ -35,6 +38,7 @@ public class IntentTransactionProcessor {
     public static final String STATUS = "STATUS"; // "RS", "PN", "UR", "CL", "RC"; see TransactionStatus
     public static final String TIMESTAMP_MILLIS = "TIMESTAMP_MILLIS"; // Unix timestamp in milliseconds, long
     public static final String TIMESTAMP_ISO8601 = "TIMESTAMP_ISO8601"; // "2026-09-10T19:57:45+08:00"
+    public static final String TAGS = "TAGS"; // String ("food" or "food, groceries"), String[], or ArrayList<String>
 
     private static BigDecimal HUNDRED = new BigDecimal(100);
 
@@ -137,6 +141,14 @@ public class IntentTransactionProcessor {
                 tx.isCCardPayment = 1;
             }
 
+            List<String> tags = extractTagsFromIntent(intent);
+            if (!tags.isEmpty()) {
+                for (String t : tags) {
+                    db.findOrInsertEntityByTitle(Tag.class, t);
+                }
+                tx.tags = String.join(", ", tags);
+            }
+
             long timestampMillis = intent.getLongExtra(TIMESTAMP_MILLIS, 0);
             if (timestampMillis != 0) {
                 tx.dateTime = timestampMillis;
@@ -157,5 +169,52 @@ public class IntentTransactionProcessor {
         }
 
         return null;
+    }
+
+    public static List<String> extractTagsFromIntent(Intent intent) {
+        if (intent == null) return Collections.emptyList();
+        List<String> result = new ArrayList<>();
+
+        // 1. Check String arrays / ArrayLists first
+        for (String key : new String[]{"TAGS", "tags"}) {
+            String[] arr = intent.getStringArrayExtra(key);
+            if (arr != null && arr.length > 0) {
+                for (String s : arr) {
+                    addTagToList(result, s);
+                }
+                return result;
+            }
+            ArrayList<String> list = intent.getStringArrayListExtra(key);
+            if (list != null && !list.isEmpty()) {
+                for (String s : list) {
+                    addTagToList(result, s);
+                }
+                return result;
+            }
+        }
+
+        // 2. Check String extra (single tag e.g. "Coffee" or comma/semicolon-separated tags e.g. "Coffee, Food")
+        for (String key : new String[]{"TAGS", "tags"}) {
+            String val = intent.getStringExtra(key);
+            if (val != null && !val.trim().isEmpty()) {
+                for (String s : val.split("[,;]")) {
+                    addTagToList(result, s);
+                }
+                if (!result.isEmpty()) {
+                    return result;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static void addTagToList(List<String> list, String s) {
+        if (s != null) {
+            String trimmed = s.trim();
+            if (!trimmed.isEmpty() && !list.contains(trimmed)) {
+                list.add(trimmed);
+            }
+        }
     }
 }

--- a/app/src/main/java/tw/tib/financisto/service/IntentTransactionProcessor.java
+++ b/app/src/main/java/tw/tib/financisto/service/IntentTransactionProcessor.java
@@ -146,7 +146,7 @@ public class IntentTransactionProcessor {
                 for (String t : tags) {
                     db.findOrInsertEntityByTitle(Tag.class, t);
                 }
-                tx.tags = String.join(", ", tags);
+                tx.tags = String.join("\n", tags);
             }
 
             long timestampMillis = intent.getLongExtra(TIMESTAMP_MILLIS, 0);
@@ -193,11 +193,11 @@ public class IntentTransactionProcessor {
             }
         }
 
-        // 2. Check String extra (single tag e.g. "Coffee" or comma/semicolon-separated tags e.g. "Coffee, Food")
+        // 2. Check String extra (single tag e.g. "Coffee" or newline/comma/semicolon-separated tags e.g. "Coffee, Food")
         for (String key : new String[]{"TAGS", "tags"}) {
             String val = intent.getStringExtra(key);
             if (val != null && !val.trim().isEmpty()) {
-                for (String s : val.split("[,;]")) {
+                for (String s : val.split("[\n,;]")) {
                     addTagToList(result, s);
                 }
                 if (!result.isEmpty()) {

--- a/app/src/main/java/tw/tib/financisto/utils/MyPreferences.java
+++ b/app/src/main/java/tw/tib/financisto/utils/MyPreferences.java
@@ -446,6 +446,14 @@ public class MyPreferences {
 		return Integer.parseInt(getString("ntsl_show_project_order", "4"));
 	}
 
+	public static boolean isShowTags() {
+		return getBoolean("ntsl_show_tags", true);
+	}
+
+	public static int getTagsOrder() {
+		return Integer.parseInt(getString("ntsl_show_tags_order", "4"));
+	}
+
 	public static boolean isUseTwinDatePicker() {
 		return getBoolean("ntsl_use_twin_date_picker", false);
 

--- a/app/src/main/java/tw/tib/financisto/utils/TransactionTitleUtils.java
+++ b/app/src/main/java/tw/tib/financisto/utils/TransactionTitleUtils.java
@@ -24,6 +24,7 @@ public class TransactionTitleUtils {
     private ForegroundColorSpan payeeSpan;
     private ForegroundColorSpan locationSpan;
     private ForegroundColorSpan noteSpan;
+    private ForegroundColorSpan tagSpan;
     private ForegroundColorSpan transferSpan;
 
     public TransactionTitleUtils(Context context, boolean colorizeItem) {
@@ -36,7 +37,24 @@ public class TransactionTitleUtils {
         this.payeeSpan = new ForegroundColorSpan(r.getColor(R.color.transaction_payee));
         this.locationSpan = new ForegroundColorSpan(r.getColor(R.color.transaction_location));
         this.noteSpan = new ForegroundColorSpan(r.getColor(R.color.transaction_note));
+        this.tagSpan = new ForegroundColorSpan(r.getColor(R.color.transaction_tag));
         this.transferSpan = new ForegroundColorSpan(r.getColor(R.color.transfer_color));
+    }
+
+    public static String formatTagsForDisplay(String tags) {
+        if (tags == null || tags.trim().isEmpty()) return "";
+        StringBuilder sb = new StringBuilder();
+        for (String tag : tags.split(",")) {
+            String trimmed = tag.trim();
+            if (!trimmed.isEmpty()) {
+                if (sb.length() > 0) sb.append(" ");
+                if (!trimmed.startsWith("#")) {
+                    sb.append("#");
+                }
+                sb.append(trimmed);
+            }
+        }
+        return sb.toString();
     }
 
     public CharSequence generateTransactionTitle(boolean isTransfer, String payee, String transfer, String note, String location, long categoryId, String category) {
@@ -45,6 +63,10 @@ public class TransactionTitleUtils {
         } else {
             return generateTransactionTitleForRegular(isTransfer, payee, transfer, note, location, category);
         }
+    }
+
+    public CharSequence generateTransactionTitle(boolean isTransfer, String payee, String transfer, String note, String tags, String location, long categoryId, String category) {
+        return generateTransactionTitle(isTransfer, payee, transfer, note, location, categoryId, category);
     }
 
     private CharSequence generateTransactionTitleForRegular(boolean isTransfer, String payee, String transfer, String note, String location, String category) {

--- a/app/src/main/java/tw/tib/financisto/utils/TransactionTitleUtils.java
+++ b/app/src/main/java/tw/tib/financisto/utils/TransactionTitleUtils.java
@@ -44,7 +44,7 @@ public class TransactionTitleUtils {
     public static String formatTagsForDisplay(String tags) {
         if (tags == null || tags.trim().isEmpty()) return "";
         StringBuilder sb = new StringBuilder();
-        for (String tag : tags.split(",")) {
+        for (String tag : tags.split("\n")) {
             String trimmed = tag.trim();
             if (!trimmed.isEmpty()) {
                 if (sb.length() > 0) sb.append(" ");

--- a/app/src/main/java/tw/tib/financisto/view/PillSpan.java
+++ b/app/src/main/java/tw/tib/financisto/view/PillSpan.java
@@ -1,0 +1,142 @@
+package tw.tib.financisto.view;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.TextUtils;
+import android.text.style.ReplacementSpan;
+import androidx.core.content.ContextCompat;
+import tw.tib.financisto.R;
+
+public class PillSpan extends ReplacementSpan {
+
+    private final int backgroundColor;
+    private final int textColor;
+    private final int strokeColor;
+    private final float cornerRadius;
+    private final float paddingHorizontal;
+    private final float paddingVertical;
+    private final float marginHorizontal;
+    private final float marginVertical;
+
+    public PillSpan(Context context) {
+        this(context, false);
+    }
+
+    public PillSpan(Context context, boolean isCounter) {
+        float density = context.getResources().getDisplayMetrics().density;
+        if (isCounter) {
+            this.backgroundColor = ContextCompat.getColor(context, R.color.tag_counter_bg);
+            this.textColor = ContextCompat.getColor(context, R.color.tag_counter_text);
+            this.strokeColor = ContextCompat.getColor(context, R.color.tag_counter_stroke);
+        } else {
+            this.backgroundColor = ContextCompat.getColor(context, R.color.tag_pill_bg);
+            this.textColor = ContextCompat.getColor(context, R.color.tag_pill_text);
+            this.strokeColor = ContextCompat.getColor(context, R.color.tag_pill_stroke);
+        }
+        this.cornerRadius = 5 * density;
+        this.paddingHorizontal = 7 * density;
+        this.paddingVertical = 2.5f * density;
+        this.marginHorizontal = 2 * density;
+        this.marginVertical = 2.5f * density;
+    }
+
+    @Override
+    public int getSize(Paint paint, CharSequence text, int start, int end, Paint.FontMetricsInt fm) {
+        if (fm != null) {
+            Paint.FontMetricsInt pfm = paint.getFontMetricsInt();
+            int extra = (int) Math.ceil(paddingVertical + marginVertical);
+            fm.ascent = pfm.ascent - extra;
+            fm.descent = pfm.descent + extra;
+            fm.top = pfm.top - extra;
+            fm.bottom = pfm.bottom + extra;
+        }
+        float textWidth = paint.measureText(text, start, end);
+        return (int) (textWidth + paddingHorizontal * 2 + marginHorizontal * 2);
+    }
+
+    @Override
+    public void draw(Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, Paint paint) {
+        float textWidth = paint.measureText(text, start, end);
+        float pillLeft = x + marginHorizontal;
+        float pillRight = pillLeft + textWidth + paddingHorizontal * 2;
+
+        Paint.FontMetricsInt fm = paint.getFontMetricsInt();
+        float pillTop = y + fm.ascent - paddingVertical;
+        float pillBottom = y + fm.descent + paddingVertical;
+
+        RectF rect = new RectF(pillLeft, pillTop, pillRight, pillBottom);
+
+        int origColor = paint.getColor();
+        Paint.Style origStyle = paint.getStyle();
+
+        // 1. Draw rounded pill background
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(backgroundColor);
+        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint);
+
+        // 2. Draw border
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setStrokeWidth(1f);
+        paint.setColor(strokeColor);
+        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint);
+
+        // 3. Draw text inside pill
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(textColor);
+        canvas.drawText(text, start, end, pillLeft + paddingHorizontal, y, paint);
+
+        // Restore paint
+        paint.setColor(origColor);
+        paint.setStyle(origStyle);
+    }
+
+    public static CharSequence formatAsPills(Context context, String tagsString) {
+        if (TextUtils.isEmpty(tagsString)) {
+            return "";
+        }
+        String[] tags = tagsString.split("[,;]");
+        java.util.List<String> validTags = new java.util.ArrayList<>();
+        for (String tag : tags) {
+            String trimmed = tag.trim();
+            if (!trimmed.isEmpty()) {
+                validTags.add(trimmed);
+            }
+        }
+        if (validTags.isEmpty()) {
+            return "";
+        }
+
+        final int MAX_INLINE_TAGS = 4;
+        boolean hasOverflow = validTags.size() > MAX_INLINE_TAGS;
+        int displayCount = hasOverflow ? 3 : validTags.size();
+
+        SpannableStringBuilder ssb = new SpannableStringBuilder();
+        for (int i = 0; i < displayCount; i++) {
+            if (ssb.length() > 0) {
+                ssb.append(" ");
+            }
+            int start = ssb.length();
+            ssb.append(validTags.get(i));
+            int end = ssb.length();
+            ssb.setSpan(new PillSpan(context, false), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+
+        if (hasOverflow) {
+            int remaining = validTags.size() - displayCount;
+            String counterText = "+" + remaining + " more";
+            if (ssb.length() > 0) {
+                ssb.append(" ");
+            }
+            int start = ssb.length();
+            ssb.append(counterText);
+            int end = ssb.length();
+            ssb.setSpan(new PillSpan(context, true), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+
+        return ssb;
+    }
+}

--- a/app/src/main/java/tw/tib/financisto/view/PillSpan.java
+++ b/app/src/main/java/tw/tib/financisto/view/PillSpan.java
@@ -98,7 +98,7 @@ public class PillSpan extends ReplacementSpan {
         if (TextUtils.isEmpty(tagsString)) {
             return "";
         }
-        String[] tags = tagsString.split("[,;]");
+        String[] tags = tagsString.split("\n");
         java.util.List<String> validTags = new java.util.ArrayList<>();
         for (String tag : tags) {
             String trimmed = tag.trim();

--- a/app/src/main/res/drawable/ic_action_tag.xml
+++ b/app/src/main/res/drawable/ic_action_tag.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M814,446L514,146C495,127 469,116 442,116L200,116C156,116 120,152 120,196L120,438C120,465 131,491 150,510L450,810C469,829 495,840 522,840C549,840 575,829 594,810L814,590C833,571 844,545 844,518C844,491 833,465 814,446ZM522,768L200,446L200,196L450,196L772,518L522,768ZM325,275C353,275 375,297 375,325C375,353 353,375 325,375C297,375 275,353 275,325C275,297 297,275 325,275Z"/>
+</vector>

--- a/app/src/main/res/layout/select_entry_with_2btn_and_filter.xml
+++ b/app/src/main/res/layout/select_entry_with_2btn_and_filter.xml
@@ -56,14 +56,14 @@
 					  a:layout_height="wrap_content" a:layout_below="@+id/label"
 					  a:layout_alignLeft="@+id/label" a:textAppearance="?android:attr/textAppearanceMedium"
 					  a:textColor="@android:color/primary_text_dark"
-					  a:maxLines="2" a:duplicateParentState="true"/>
+					  a:duplicateParentState="true"/>
 		</RelativeLayout>
 
 		<ImageView a:id="@+id/more"
 				   style="@style/MoreButton"
-					a:layout_width="wrap_content"
+				   a:layout_width="wrap_content"
 				   a:layout_height="wrap_content"
-				   a:layout_gravity="bottom"
+				   a:layout_gravity="center_vertical"
 				   a:duplicateParentState="true" />
 
 		<ImageView style="@style/MinusButton"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,6 +28,13 @@
     <color name="transaction_note">@android:color/secondary_text_dark</color>
     <color name="transaction_payee">@android:color/holo_blue_light</color>
     <color name="transaction_location">@android:color/holo_green_light</color>
+    <color name="transaction_tag">@color/holo_orange_light</color>
+    <color name="tag_pill_bg">#25272D</color>
+    <color name="tag_pill_stroke">#3D414C</color>
+    <color name="tag_pill_text">#E4E6EB</color>
+    <color name="tag_counter_bg">#1A2B3C</color>
+    <color name="tag_counter_stroke">#33B5E5</color>
+    <color name="tag_counter_text">#33B5E5</color>
     <color name="transaction_date">#999</color>
     <color name="transaction_date_weekend">#c66</color>
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -32,6 +32,10 @@
 	<item name="note" type="id" />
 	<item name="note_clear" type="id" />
 	<item name="note_add" type="id" />
+	<item name="tags" type="id" />
+	<item name="tags_clear" type="id" />
+	<item name="tags_add" type="id" />
+	<item name="tags_filter_toggle" type="id" />
 	<item name="split" type="id" />
 	<item name="split_clear" type="id" />
 	<item name="currency" type="id" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,15 @@
     <string name="move_go_to_marker">Go to marker</string>
     <string name="tap_location">Tap \'My location\' marker to manually adjust location</string>
     <string name="note">Note</string>
+    <string name="tag">Tag</string>
+    <string name="tags">Tags</string>
+    <string name="no_tags">No tags</string>
+    <string name="select_tags">Select tags…</string>
+    <string name="new_tag">New Tag</string>
+    <string name="enter_tag_name">Enter tag name</string>
+    <string name="tags_hint">tag1, tag2…</string>
+    <string name="tags_filter">Tags containing</string>
+    <string name="tags_filter_value">Tag \"%1$s\"</string>
     <string name="note_text_containing">Note text containing</string>
     <string name="note_text_containing_value">Containing \"%1$s\"</string>
     <string name="service_is_not_available">Service is not available, please try again later</string>
@@ -371,6 +380,10 @@
     <string name="show_project_summary">Show project drop-down (requires restart)</string>
     <string name="show_project_order">Project order</string>
     <string name="show_project_order_summary">Relative position for the project drop-down</string>
+    <string name="show_tags">Show tags</string>
+    <string name="show_tags_summary">Show tags drop-down (requires restart)</string>
+    <string name="show_tags_order">Tags order</string>
+    <string name="show_tags_order_summary">Relative position for the tags drop down</string>
     <string name="remember_selection">Remember the selection</string>
     <string name="remember_last_account">Last account</string>
     <string name="remember_last_account_summary">Remember the last selected account</string>

--- a/app/src/main/res/xml/pref_transaction.xml
+++ b/app/src/main/res/xml/pref_transaction.xml
@@ -199,6 +199,21 @@
         <SwitchPreferenceCompat
             app:singleLineTitle="false"
             android:defaultValue="true"
+            android:key="ntsl_show_tags"
+            android:summary="@string/show_tags_summary"
+            android:title="@string/show_tags" />
+        <ListPreference
+            app:singleLineTitle="false"
+            android:defaultValue="4"
+            android:dependency="ntsl_show_tags"
+            android:entries="@array/sort_order_entities"
+            android:entryValues="@array/sort_order_entities"
+            android:key="ntsl_show_tags_order"
+            android:summary="@string/show_tags_order_summary"
+            android:title="@string/show_tags_order" />
+        <SwitchPreferenceCompat
+            app:singleLineTitle="false"
+            android:defaultValue="true"
             android:key="ntsl_show_picture"
             android:summary="@string/show_picture_summary"
             android:title="@string/show_picture" />


### PR DESCRIPTION
feat: add transaction tagging, autocomplete, intent support, and multi-choice filter

- Enable/disable tags in transaction via Preferences > New transaction screen (with layout ordering)
- Add Tag entity, database schema migrations, and Tag management activity
- Add TagSelector with autocomplete, multi-choice picker, and pill styling in blotter
- Support TAGS extra in intent transaction processor (single, comma-separated, array, list)
- Add multi-choice checkbox dialog filter for tags in blotter filter