### PR TITLE
Keep {{e}} non-greedy; extend an unanchored trailing {{e}} to the end of its line

### DIFF
--- a/app/src/androidTest/java/tw/tib/financisto/service/PlaceholderCaptureTest.java
+++ b/app/src/androidTest/java/tw/tib/financisto/service/PlaceholderCaptureTest.java
@@ -63,6 +63,23 @@ public class PlaceholderCaptureTest {
         assertEquals("(旅遊儲蓄金)", captureTransferTo("(旅遊儲蓄金)"));
     }
 
+    /**
+     * The end-of-line rule is decided by the placeholder's pattern, not by {{e}} specifically:
+     * {{x}} / {{c}} / {{r}} are (\S+?) and used to capture one character at the end of a template
+     * too. With the rule they capture the whole last word of the line. Because \S cannot cross a
+     * space, a value followed by more words on the same line makes the template not match at
+     * all — better than the silent one-character account name that failed the lookup anyway.
+     */
+    @Test
+    public void transferToAccountAtTemplateEndCapturesTheLastWord() {
+        String[] match = SmsTransactionProcessor.findTemplateMatches(
+                "transfer {{p}} to {{x}}", "transfer 100 to Visa-Gold\nthank you");
+        assertNotNull("template did not match", match);
+        assertEquals("Visa-Gold", match[Placeholder.TRANSFER_TO_ACCOUNT_NAME.ordinal()]);
+        assertNull(SmsTransactionProcessor.findTemplateMatches(
+                "transfer {{p}} to {{x}}", "transfer 100 to Visa Gold done"));
+    }
+
     // --- {{e}} (payee / merchant) ---
 
     /** The usual shape of a card notification: the merchant sits between two fixed labels. */
@@ -106,6 +123,54 @@ public class PlaceholderCaptureTest {
                         + "卡號末四碼5678於 2026/08/17 13:57在SHOPFAST TW 刷卡。立即查看消費明細");
         assertNotNull("template did not match", match);
         assertEquals("SHOPFAST TW", match[Placeholder.PAYEE.ordinal()]);
+    }
+
+    /**
+     * A template that ends with {{e}} has no closing anchor. A lazy capture used to settle for
+     * a single character there ("SHOPFAST TW" -> "S"); it now runs to the end of the line, and
+     * the next line is not pulled in. A message that ends right after the payee works too.
+     */
+    @Test
+    public void payeeAtTemplateEndCapturesToEndOfLine() {
+        String[] match = SmsTransactionProcessor.findTemplateMatches(
+                "金額NT${{p}}元{{*}}在{{e}}",
+                "丙銀行 【刷卡通知】金額NT$205元 \n卡號末四碼5678於 2026/08/17 13:57在SHOPFAST TW\n立即查看消費明細");
+        assertNotNull("template did not match", match);
+        assertEquals("SHOPFAST TW", match[Placeholder.PAYEE.ordinal()]);
+        match = SmsTransactionProcessor.findTemplateMatches("金額{{p}}元在{{e}}", "丙銀行 金額205元在NeoShop");
+        assertNotNull("template did not match at end of message", match);
+        assertEquals("NeoShop", match[Placeholder.PAYEE.ordinal()]);
+    }
+
+    /**
+     * {{e}} followed only by a trailing {{*}} (to ignore whatever comes after) has no anchor
+     * either: same treatment, the payee runs to the end of its line and {{*}} takes the rest.
+     * {{e}}{{*}} followed by fixed text is left alone — the wildcard then has to reach that text.
+     */
+    @Test
+    public void payeeBeforeTrailingWildcardCapturesToEndOfLine() {
+        String[] match = SmsTransactionProcessor.findTemplateMatches(
+                "金額NT${{p}}元{{*}}在{{e}}{{*}}",
+                "丙銀行 【刷卡通知】金額NT$205元 \n卡號末四碼5678於 2026/08/17 13:57在SHOPFAST TW\n立即查看消費明細");
+        assertNotNull("template did not match", match);
+        assertEquals("SHOPFAST TW", match[Placeholder.PAYEE.ordinal()]);
+    }
+
+    /**
+     * The closing anchor occurs more than once on the line — "merchant, disclaimer, more,
+     * thanks" is the usual shape of a card notification here. A lazy capture stops at the
+     * first anchor and yields the merchant; a greedy one runs to the last anchor and the
+     * whole disclaimer becomes the payee. Adding more fixed text after {{e}} does not help
+     * when the anchor itself is what repeats.
+     */
+    @Test
+    public void payeeStopsAtTheFirstAnchorEvenWithALongTail() {
+        String[] match = SmsTransactionProcessor.findTemplateMatches(
+                "丙銀行 {{*}}末四碼{{a}}{{*}}台幣{{p}}元，商店名稱:{{e}}，",
+                "丙銀行 丙銀行信用卡末四碼4321刷卡通知1150819_20:57金額台幣1,838元，商店名稱:測試商行，"
+                        + "實際商店名稱請以信用卡帳單列示為準，實際請款金額以帳單所列為準如有疑問請撥打卡片背面服務專線，謝謝！");
+        assertNotNull("template did not match", match);
+        assertEquals("測試商行", match[Placeholder.PAYEE.ordinal()]);
     }
 
     /**

--- a/app/src/main/java/tw/tib/financisto/service/SmsTransactionProcessor.java
+++ b/app/src/main/java/tw/tib/financisto/service/SmsTransactionProcessor.java
@@ -295,6 +295,17 @@ public class SmsTransactionProcessor {
         String[] results = null;
         template = preprocessPatterns(template);
         final int[] phIndexes = findPlaceholderIndexes(template);
+        // A lazy capture with nothing after it has no closing anchor, and find() does not require
+        // the match to reach the end of the message, so it settles for a single character
+        // ("NeoShop" -> "N"). That happens when the template ends with the placeholder, or ends
+        // with the placeholder followed by {{*}} (a wildcard swallowing the rest of the message
+        // is not an anchor either). Extend the capture to the end of its line in both cases.
+        // Captures followed by fixed text are unchanged: they still stop at the first
+        // occurrence of that text.
+        final boolean endsWithLazyCapture = endsWithLazyCapture(template);
+        final boolean endsWithLazyCaptureThenAny = !endsWithLazyCapture
+                && template.endsWith(ANY.code)
+                && endsWithLazyCapture(template.substring(0, template.length() - ANY.code.length()));
 
         if (phIndexes != null) {
             // escape regex characters (i.e. can't use regex in template)
@@ -306,6 +317,13 @@ public class SmsTransactionProcessor {
                 }
             }
             template = template.replace(ANY.code, ANY.regexp);
+            if (endsWithLazyCapture) {
+                template += END_OF_LINE;
+            } else if (endsWithLazyCaptureThenAny) {
+                // the compiled template ends with ANY's pattern; the anchor goes right before it
+                template = template.substring(0, template.length() - ANY.regexp.length())
+                        + END_OF_LINE + ANY.regexp;
+            }
             Log.d(TAG, "template=" + template);
 
             Matcher matcher = Pattern.compile(template, DOTALL).matcher(sms);
@@ -320,6 +338,19 @@ public class SmsTransactionProcessor {
             }
         }
         return results;
+    }
+
+    /** Lookahead appended to a lazy capture that has no anchor: expand to the end of the line, not beyond. */
+    private static final String END_OF_LINE = "(?=[\\r\\n]|$)";
+
+    /** True when the template ends with a placeholder whose pattern is a lazy capture, e.g. ([^\r\n]+?). */
+    static boolean endsWithLazyCapture(String template) {
+        for (Placeholder p : Placeholder.values()) {
+            if (template.endsWith(p.code)) {
+                return p.regexp.endsWith("?)");
+            }
+        }
+        return false;
     }
 
     private static String preprocessPatterns(String template) {
@@ -384,9 +415,14 @@ public class SmsTransactionProcessor {
         // [^\r\n] is a superset of \S, and both are non-greedy, so they expand identically
         // until a space is needed — every template that matched before matches the same
         // way, and only previously-failing ones start to match.
+        // Non-greedy on purpose: with a fixed anchor after it the capture stops at the *first*
+        // occurrence of that anchor. A greedy capture runs to the last one on the line, so
+        // "merchant, <disclaimer>, <more>, thanks" would put the whole disclaimer into the
+        // payee. A template that ends with {{e}} (no anchor at all) is handled in
+        // findTemplateMatches() by extending the capture to the end of the line.
         // Covered by PlaceholderCaptureTest in androidTest — it has to run on a device,
         // because Android's regex is ICU-backed and a desktop JVM answers differently.
-        PAYEE("<:E:>", "([^\\r\\n]+)", "{{e}}"),
+        PAYEE("<:E:>", "([^\\r\\n]+?)", "{{e}}"),
         CURRENCY("<:F:>", "([A-Z]{3})", "{{f}}"),
         TIMESTAMP_MILLIS("<:G:>", "(\\d{1,13})", "{{g}}"),
         PRICE("<:P:>", BALANCE.regexp, "{{p}}"),


### PR DESCRIPTION
## Motivation

v257 made `{{e}}` greedy (`([^\r\n]+)`) so that a template ending in `{{e}}` no longer captures a single character (#149). It fixes that shape, but it changes every template that has fixed text *after* `{{e}}`: a greedy capture followed by an anchor runs to the **last** occurrence of that anchor on the line, not the first.

Card notifications here very commonly look like this (merchant name changed, everything else verbatim):

```
丙銀行信用卡末四碼4321刷卡通知1150819_20:57金額台幣1,838元，商店名稱:測試商行，實際商店名稱請以信用卡帳單列示為準，實際請款金額以帳單所列為準如有疑問請撥打卡片背面服務專線，謝謝！
```

with the template `…台幣{{p}}元，商店名稱:{{e}}，`. On v256 the payee is `測試商行`. On v257 it is

```
測試商行，實際商店名稱請以信用卡帳單列示為準，實際請款金額以帳單所列為準如有疑問請撥打卡片背面服務專線
```

Payees are created on first sight, so each such notification creates a new payee carrying the bank's disclaimer, and the payee's remembered category stops working. The what's-new note suggests anchoring with fixed text after the payee — that does not help here, because the anchor (`，`) is exactly what repeats on the line, and copying the disclaimer into the template ties it to wording the bank changes freely.

## Implementation

Keep `{{e}}` lazy (`([^\r\n]+?)`) and handle #149 where it actually lives: when **nothing anchors the capture** — the template ends with the placeholder, or ends with the placeholder followed only by `{{*}}` — `findTemplateMatches()` appends a `(?=[\r\n]|$)` lookahead to the capture, so it extends to the end of its line instead of stopping after one character. Captures followed by fixed text are unchanged and stop at the first occurrence of that text, as before v257.

So the rule is decided by whether an anchor exists, not by greediness: **anchor → first occurrence; no anchor → end of line.** `endsWithLazyCapture()` checks the last placeholder's pattern rather than hard-coding `{{e}}`, so `{{c}}`/`{{r}}`/`{{x}}` (`(\S+?)`) and `{{t}}` (`(.*?)`) at the end of a template get the same treatment — they had the same one-character problem and v257 did not touch them. For the `\S`-based ones this means the whole last word of the line; a value followed by more words on the same line makes the template not match, instead of capturing one character that fails the entity lookup anyway. Numeric placeholders (`{{p}}`, `{{a}}`, `{{g}}`, `{{k}}`, `{{f}}`, `{{d}}`) are bounded by their own character classes and are not affected. `{{e}}{{*}}<fixed text>` is deliberately left alone: there the wildcard has to reach the fixed text, and forcing the payee to the line end would make such templates stop matching.

## Testing

Four new cases in `PlaceholderCaptureTest` (androidTest, ICU regex), run on the API 35 x86_64 emulator:

- `payeeAtTemplateEndCapturesToEndOfLine` — template `金額NT${{p}}元{{*}}在{{e}}` on a three-line notification captures `SHOPFAST TW` (whole line, next line not included); a message ending right after the payee captures `NeoShop`. **Passes on master (greedy) and with this change** — #149 stays fixed.
- `payeeBeforeTrailingWildcardCapturesToEndOfLine` — `…在{{e}}{{*}}`: same result, `{{*}}` takes the following lines. Passes on both.
- `transferToAccountAtTemplateEndCapturesTheLastWord` — `transfer {{p}} to {{x}}` on `transfer 100 to Visa-Gold\nthank you` captures `Visa-Gold` (master: `V`); with `Visa Gold done` on the same line the template does not match (master: `V`).
- `payeeStopsAtTheFirstAnchorEvenWithALongTail` — the template/notification above. **Fails on master**: `expected:<測試商行> but was:<測試商行，實際商店名稱請以信用卡帳單列示為準，實際請款金額以帳單所列為準如有疑問請撥打卡片背面服務專線>`. Passes with this change.

With the change: `PlaceholderCaptureTest` 12/12 on device. `testDebugUnitTest`: the 4 pre-existing failures in `GoogleWalletNotificationParserTest` are unrelated (this PR only touches `SmsTransactionProcessor` and the test above).

## Known limitations

- Anyone who rewrote a template in the last day to rely on greedy semantics (expecting the capture to reach the *last* anchor) would see it flip back. Everything before v257 was lazy, so this returns to the behaviour existing templates were written against.
- `{{e}}{{*}}<fixed text>` (wildcard right after the payee, then more text on the same line) is the one shape where greedy did better: greedy backtracks and hands the payee everything up to the fixed text, lazy captures one character as before v257. It is not touched here because forcing the payee to the line end would make such templates stop matching; the fix for that template is to drop the `{{*}}` and anchor on the fixed text directly.
- A template that ends with `{{e}}` while the notification continues on the same line still captures the rest of that line — that is inherent to having no anchor, and is the same result greedy gives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
